### PR TITLE
Make DCO links consistent with the taxonomy repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ SPDX-License-Identifier: Apache-2.0
 
 We have tried to make it as easy as possible to make contributions. This
 applies to how we handle the legal aspects of contribution. We use the
-same approach - the [Developer's Certificate of Origin 1.1 (DCO)](https://github.com/hyperledger/fabric/blob/master/docs/source/DCO1.1.txt) - that the Linux® Kernel [community](https://elinux.org/Developer_Certificate_Of_Origin)
+same approach - the [Developer's Certificate of Origin 1.1 (DCO)](https://developercertificate.org/) - that the Linux® Kernel [community](https://docs.kernel.org/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin)
 uses to manage code contributions.
 
 We simply ask that when submitting a patch for review, the developer


### PR DESCRIPTION
Use developercertificate.org and docs.kernel.org links for further information on the Developer's Certificate of Origin.

Reflects changes made in instruct-lab/taxonomy/pull/70.