### PR TITLE
Governance Revision: delay implementation of org-wide maintainers

### DIFF
--- a/COCC.md
+++ b/COCC.md
@@ -1,0 +1,7 @@
+# Code of Conduct Committee Members
+
+The current members of the CoCC are:
+
+* Cara Delia, Red Hat
+* Joe Sepi, IBM
+* Josh Berkus, Red Hat

--- a/CONTRIBUTOR_LADDER.md
+++ b/CONTRIBUTOR_LADDER.md
@@ -1,13 +1,17 @@
 # Contributor Ladder for InstructLab
 
-This document outlines a default number of contributor roles for InstructLab projects. Promotion within the roles is based on individual participation using transparent criteria. These criteria should be re-evaluated periodically to ensure we can meet the needs of the projects with the resources available to contribute. Also, these criteria can be extended by an individual project to meet the project's specific needs.
+This document outlines a core number of contributor roles for InstructLab projects. Promotion within the roles is based on individual participation using transparent criteria. These criteria should be re-evaluated periodically to ensure we can meet the needs of the projects with the resources available to contribute.
+
+Each individual Project may add to these criteria and add additional roles as they require.  These additions will be spelled on in a Contributor Ladder file in the individual Project's main repository.
+
+Contributor roles are per-Project; being a Reviewer in CLI does not guarantee that you will have Reviewer rights in Taxonomy, for example.  Where applicable for InstructLab overall, contributor status is equal to the highest status they have on any Project.
 
 | Role       | Responsibilities                             | Requirements                                                  | Defined by                    |
 |------------|----------------------------------------------|---------------------------------------------------------------|-------------------------------|
-| Member     | Active contributor in the community          | Multiple contributions and sponsored by 2 maintainers            | InstructLab GitHub org member        |
+| Member     | Active contributor in the community          | Multiple contributions and sponsored by 2 Maintainers or Reviewers            | InstructLab GitHub org member        |
 | Triager    | Triaging issues and PRs                      | History of issue and PR triage and sponsored by 2 maintainers           | InstructLab GitHub Triage team member        |
 | Reviewer   | Reviews contributions from other contributors     | History of reviews and contributions. Sponsored by 2 maintainers.                             | CODEOWNERS/MAINTAINER file reviewer entry  |
-| Maintainer | Set direction and priorities for the project | Demonstrated responsibility and excellent technical judgement. Nominated and approved by maintainers team. | CODEOWNERS/MAINTAINER file approver entry  |
+| Maintainer | Set direction and priorities for a Project | Demonstrated responsibility and excellent technical judgement. Nominated and approved by maintainers team. | CODEOWNERS/MAINTAINER file approver entry  |
 
 The project welcomes new contributors. Not all contributors are able to provide sustained contribution, but each contribution is always welcome.  Established contributors are expected to demonstrate their adherence to the criteria in this document, familiarity with project organization, roles, policies, etc., and technical and/or writing ability. Role-specific expectations, responsibilities, and requirements are enumerated below.
 
@@ -23,10 +27,10 @@ Members are active contributors in the community. They can have issues and PRs a
     - Authoring or reviewing PRs on GitHub.
     - Filing or commenting on issues on GitHub.
     - Contributing to community discussions (e.g. meetings, Slack).
-- Sponsored by two maintainers.
+- Sponsored by two Maintainers or Reviewers
 
-If you meet the requirements, nominate yourself as below,
-- Open an issue in the repo of interest.
+Any person who meets the requirements may be nominated by an contributor (including themselves):
+- Open an issue in the repo of interest detailing your contributions to the project so far.
 - Ensure your sponsors are @mentioned on the issue.
 - Make sure that the list of contributions included is representative of your work on the project.
 
@@ -55,7 +59,7 @@ Triagers are active contributors in the community through issue and PR triage. T
 - Sponsored by two maintainers.
 
 If you meet the requirements, nominate yourself as below,
-- Open an issue in the repo of interest.
+- Open an issue in the repo of interest detailing your contributions to date.
 - Ensure your sponsors are @mentioned on the issue.
 - Make sure that the list of contributions included is representative of your work on the project.
 
@@ -74,14 +78,14 @@ Reviewers are the members with high quality code contributions and who have demo
 ### Requirements
 
 - Member for at least 1 month.
-- Primary reviewer for at least 5 PRs to the codebase with high quality reviews.
-- Knowledgeable about the codebase.
+- Primary reviewer for at least 5 PRs to the Project with high quality reviews.
+- Knowledgeable about the Project.
 - Sponsored by two maintainers.
 
-If you meet the requirements, nominate yourself to become a reviewer by sending an email to maintainers with your candidacy.
+If you meet the requirements, nominate yourself to become a reviewer by filing an issue in the appropriate Project:
 - Ensure your sponsors are @mentioned on the email.
-- Include a list of contributions representative of your work on the project.
-- Existing maintainers will vote privately and respond to the email with either acceptance or with feedback for suggested improvement.
+- Include a list of contributions representative of your work.
+- Existing maintainers will vote privately and respond to the issue with either acceptance or with feedback for suggested improvement.  Such feedback may be given privately.
 - Upon all maintainers agreement or lazy consensus among them in a three week time frame, a maintainer will create PR to add you in the CODEOWNERS/MAINTAINER file.
 
 ### Responsibilities and Privileges
@@ -95,7 +99,7 @@ If you meet the requirements, nominate yourself to become a reviewer by sending 
 
 ## Maintainer
 
-Maintainers are first and foremost contributors that have shown they are committed to the long term success of a project. Maintainership is about building trust with the current maintainers and being a person that they can depend on to make decisions in the best interest of the project in a consistent manner.
+Maintainers are first and foremost contributors that have shown they are committed to the long term success of a project. Maintainership is about building trust with the community and being a person that everyone can depend on to make consistent decisions in the best interest of the project.
 
 **Defined by:** *approvers* entry in the CODEOWNERS/MAINTAINER file.
 
@@ -129,11 +133,17 @@ If you meet the requirements, nominate yourself to become a maintainer by sendin
 - Work with other maintainers to maintain the project's overall health and success holistically.
 - Unless otherwise specified, maintainers of a project are the github users with permission to merge commits to the project repository branches.
 
-### Stepping Down/Emeritus Process
+## Stepping Down/Emeritus Process
 
-Life priorities, interests, and passions can change. Maintainers can retire and move to emeritus maintainers. If a maintainer needs to step down, they should inform other maintainers, if possible, help find someone to pick up the related work. At the very least, ensure the related work can be continued. Afterward they can remove themselves from the list of existing maintainers.
+Life priorities, interests, and passions can change. Contributors can retire and move to emeritus maintainers. If a contributor needs to step down from their current role, they should inform the appropriate Project Maintainers.  No vote is required for a contributor to remove themselves, and any maintainer can approve the PR.  Maintainers who step down become Emeritus Maintainers.
 
-If a maintainer has not been performing their duties for a consecutive period of 12 months, they can be removed by the other maintainers from the active maintainer list. In that case the inactive maintainer will be first notified via an email. If the situation doesn't improve, they will be moved from the active list to an emeritus list. If an emeritus maintainer wants to regain an active role, they can do so by renewing their contributions. Active maintainers should welcome such a move. Retiring of other maintainers or regaining the status should require approval of at least two active maintainers.
+If a contributor has not been performing the duties of their role for a consecutive period of 12 months, they can be removed by the appropriate Project Maintainers. The Maintainers will make reasonable efforts to contact the absent contributor. If the Code of Conduct Committee recommends that a contributor be removed from their role, this will also be carried out by the Project Maintainers.  
+
+If an emeritus maintainer or other retired contributor wants to regain an active role, they can do so by renewing their contributions, after which they can be re-enstated by a decision of the appropriate Project Maintainers.
+
+## Changes to this Contributor Ladder
+
+Changes to the Contributor Ladder must be approved via a vote of the Oversight Committee or a majority of existing Project Maintainer.
 
 ## Acknowledgements
 

--- a/CONTRIBUTOR_LADDER.md
+++ b/CONTRIBUTOR_LADDER.md
@@ -29,7 +29,7 @@ Members are active contributors in the community. They can have issues and PRs a
     - Contributing to community discussions (e.g. meetings, Slack).
 - Sponsored by two Maintainers or Reviewers
 
-Any person who meets the requirements may be nominated by an contributor (including themselves):
+Any person who meets the requirements may be nominated by a contributor (including themselves):
 - Open an issue in the repo of interest detailing your contributions to the project so far.
 - Ensure your sponsors are @mentioned on the issue.
 - Make sure that the list of contributions included is representative of your work on the project.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,7 +3,7 @@ Maintainers
 
 **CLI Maintainers**
 
-| Name                    | GitHub 
+| Name                    | GitHub
 |-------------------------|--------
 | Andrea Frittoli         | [afrittoli][afrittoli]
 | BJ Hargrave             | [bjhargrave][bjhargrave]
@@ -21,7 +21,7 @@ Maintainers
 
 **CLI Triagers**
 
-| Name                    | GitHub 
+| Name                    | GitHub
 |-------------------------|--------
 | Aakanksha Duggal        | [aakankshaduggal][aakankshaduggal]
 | Abhishek Bhandwaldar    | [abhi1092][abhi1092]
@@ -39,7 +39,7 @@ Maintainers
 
 **Community Maintainers**
 
-| Name                    | GitHub 
+| Name                    | GitHub
 |-------------------------|--------
 | Cara Delia              | [caradelia][caradelia]
 | Carol Chen              | [cybette][cybette]
@@ -49,27 +49,9 @@ Maintainers
 | Martin Hickey           | [hickeyma][hickeyma]
 | Mingxuan Zhao           | [mingxzhao][mingxzhao]
 
-**Instruct Lab Org Maintainers**
-
-| Name                    | GitHub 
-|-------------------------|--------
-| Akash Srivastava        | [akashgit][akashgit]
-| Aldo Pareja             | [aldopareja][aldopareja]
-| darrellreimer           | [darrellreimer][darrellreimer]
-| Jeremy Eder             | [jeremyeder][jeremyeder]
-| JJ Asghar               | [jjasghar][jjasghar]
-| Joe Sepi                | [joesepi][joesepi]
-| Kai Xu                  | [xukai92][xukai92]
-| luke-inglis             | [luke-inglis][luke-inglis]
-| Mairin Duffy            | [mairin][mairin]
-| Mark Sturdevant         | [markstur][markstur]
-| Martin Hickey           | [hickeyma][hickeyma]
-| Matt Hicks              | [matthicksj][matthicksj]
-| Shiv                    | [shivchander][shivchander]
-
 **Taxonomy Approvers**
 
-| Name                    | GitHub 
+| Name                    | GitHub
 |-------------------------|--------
 | Abhishek Bhandwaldar    | [abhi1092][abhi1092]
 | Akash Srivastava        | [akashgit][akashgit]
@@ -79,7 +61,7 @@ Maintainers
 
 **Taxonomy Maintainters**
 
-| Name                    | GitHub 
+| Name                    | GitHub
 |-------------------------|--------
 | Arnaud J Le Hors        | [lehors][lehors]
 | BJ Hargrave             | [bjhargrave][bjhargrave]
@@ -95,7 +77,7 @@ Maintainers
 
 **Taxonomy Triagers**
 
-| Name                    | GitHub 
+| Name                    | GitHub
 |-------------------------|--------
 | Abraham Daniels         | [abrahamdaniels][abrahamdaniels]
 | Arnaud J Le Hors        | [lehors][lehors]

--- a/governance.md
+++ b/governance.md
@@ -4,7 +4,7 @@ The following document outlines how the InstructLab project governance operates.
 
 ## The InstructLab Project
 
-The InstructLab project is made up of several codebases and services with different release cycles that enable large model development. These codebases include:
+The InstructLab project is made up of several Projects, defined as codebases and services with different release cycles, that enable large model development. These Projects currently include:
 
 * cli - a tool to chat and train models
 * taxonomy - tree that enables model creation tuned with your data
@@ -14,48 +14,57 @@ The services provided include:
 * Documentation for those who want to chat, and train models
 * Public taxonomy collaboration
 
-## Maintainers Structure
+## Governance Structure and Roadmap
 
-There are two levels of maintainers for InstructLab. The InstructLab org maintainers oversee the overall project and its health. Project maintainers focus on a single codebase, a group of related codebases, a service (e.g., a website), or project to support the other projects (e.g., marketing or community management).
+The InstructLab Project will evolve into a two-level governance structure with an Oversight Committee and Project Maintainers.  In order to avoid unnecessary overhead, at launch the project will not have a Oversight Committee. Once the majority of Project Maintainers feel that the project has grown to the point where an Oversight Committee is necessary, the Maintainers will vote to select one. Until the Oversight Committee is constituted, the duties of the Committee will be assumed by the collective Project Maintainers.
 
-Changes in maintainership have to be announced on the **TODO: InstructLab mailing list**.
+Except where otherwise noted, decisions should always start at the most local level of project governance.  For example, decisions that affect only one Project should happen within that Project. Only escalate in the the event of problems.
 
-### InstructLab Org Maintainers
+Changes in maintainership and other governance are announced on the **TODO: InstructLab mailing list**.
 
-The InstructLab Org maintainers are responsible for:
+### InstructLab Oversight Committee
+
+The InstructLab Oversight Committee (OC) will consist of 3 to 9 of the leaders of the InstructLab project who have been chosen to serve on a team to supervise the general project and its health. The Oversight Committee are selected by the project Maintainers.
+
+The Oversight Committee are responsible for:
 
 * Maintaining the mission, vision, values, and scope of the project
 * Refining the governance and charter as needed
 * Making project level decisions
-* Resolving escalated project decisions when the subteam responsible is blocked
+* Resolving escalated project decisions when the team responsible is blocked
 * Managing the InstructLab brand
 * Controlling access to InstructLab assets such as source repositories, hosting, project calendars
-* Handling code of conduct violations
-* Deciding what sub-groups are part of the InstructLab project
+* Appointing the Code of Conduct Committee
+* Deciding what projects are part of the InstructLab project
 * Overseeing the resolution and disclosure of security issues
 * Managing financial decisions related to the project
 
-Changes to org maintainers use the following:
+Until the Oversight Committee is selected, the duties above will be carried out by the collective project Maintainers.
 
-* There will be between 3 and 9 people.
-* Any project maintainer of any active (non-archived) InstructLab organization project is eligible for a position as an org maintainer.
-* An org maintainer may step down by emailing the org maintainers mailing list. Within 7 calendar days the **TODO: InstructLab mailing list** needs to be notified of the change
-* Org maintainers MUST remain active on the project. If they are unresponsive for > 3 months they will lose org maintainership unless a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the other org maintainers agrees to extend the period to be greater than 3 months
-* When there is an opening for a new org maintainer, any person who has made a contribution to any repo under the InstructLab GitHub org may nominate a suitable project maintainer of an active project as a replacement
-  * The nomination period will be three weeks starting the day after an org maintainer opening becomes available
-  * The nomination must be made via the **TODO: InstructLab mailing list**
+Once instantiated, the Oversight Committee will be selected and maintained using the following process:
+
+Any Maintainer of any active (non-archived) InstructLab organization project is eligible for a position as an org maintainer.  Once a year, the Oversight Committee will be re-elected.  The election will consist of a nomination period followed by an election period.  Any person who has made a contribution to any repo under the InstructLab GitHub org may nominate a suitable Project Maintainer of an active project.
+
+The election will proceed according to the following process:
+* The nomination period will be three weeks starting the day after an org maintainer opening becomes available
+* The nomination must be made via the **TODO: InstructLab mailing list**
 * When nominated individual(s) agrees to be a candidate for maintainership, the project maintainers may vote
-  * The voting period will be open for a minimum of three business days and will remain open until a super-majority of project maintainers has voted
-  * Only current project maintainers of active projects are eligible to vote
-  * When the number of nominated individuals matches the number of openings each individual needs to have a yes vote from a super-majority of those that voted
-  * When there are more individuals than open positions voting will use [Condorcet](https://en.wikipedia.org/wiki/Condorcet_method) ranking on [CIVS](http://civs.cs.cornell.edu/) using the [Schulze method](https://en.wikipedia.org/wiki/Schulze_method)
-* When an org maintainer steps down, they become an emeritus maintainer
+* The voting period will be open for a minimum of three business days and will remain open until a super-majority of project maintainers has voted
+* Only current project maintainers of active projects are eligible to vote
+* When the number of nominated individuals matches the number of openings each individual needs to have a yes vote from a super-majority of those that voted
+* When there are more individuals than open positions voting will use a Ranked Choice voting mehtos, such as [Condorcet](https://en.wikipedia.org/wiki/Condorcet_method)
 
-Once an org maintainer is elected, they remain a maintainer until stepping down (or, in rare cases, are removed). Voting for new maintainers occurs when necessary to fill vacancies. Any existing project maintainer is eligible to become an org maintainer.
+Aside from the elections, the Oversight Committee members may leave the committee as follows:
 
-The Org Maintainers will select a chair to set agendas and call meetings of the Org Maintainers.
+* A member may step down by emailing the Oversight Committee mailing list. Within 7 calendar days the **TODO: InstructLab mailing list** will be notified of the change
+* Committee members MUST remain active on the project. If they are unexpectedly unresponsive for more than 3 months, or are otherwise not fulfilling their duties, or have violated the Code of Conduct, they may be removed by a vote of a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the remaining OC members
+* After an OC member steps down, they become an emeritus maintainer
+
+The Oversight Committee will select a chair to set agendas and call meetings.  Some meetings of the Oversight Committee will be public, and others will be private, at the OC's discretion.
 
 ### Project Maintainers
+
+Project Maintainers focus on a single codebase, a group of related codebases, a service (e.g., a website), or project to support the other projects (e.g., marketing or community management).
 
 Project maintainers are responsible for activities surrounding the development and release of code, the operation of any services they own (e.g., the documentation site), or the tasks needed to execute their project (e.g., community management, setting up an event booth). Technical decisions for code resides with the project maintainers unless there is a decision related to cross maintainer groups that cannot be resolved by those groups. Those cases can be escalated to the org maintainers.
 
@@ -63,15 +72,9 @@ In some cases a groups of maintainers are responsible for more than one repo (e.
 
 To be considered active maintainers, it is required for maintainers to be associated with at least one active, non-archived project. If only listed on archived projects, they become emeritus project maintainers and are no longer eligible to become org maintainers.
 
-Project maintainers do not need to be software developers. No explicit role is placed upon them and they can be anyone appropriate for the work being produced. For example, if a repository is for documentation it would be appropriate for maintainers to be editors.
+Project maintainers do not need to be software developers, but they do need to be substantial contributors.  For example, if a repository is for documentation it would be appropriate for maintainers to be editors.
 
-Changes to maintainers use the following:
-
-* A maintainer may step down by emailing the **TODO: InstructLab mailing list**
-* Maintainers MUST remain active. If they are unresponsive for > 3 months they will be automatically removed unless a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the other project maintainers agrees to extend the period to be greater than 3 months
-* New maintainers can be added to a project by a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) vote of the existing maintainers. While nomination will happen on the public **TODO: InstructLab mailing list**, voting will happen on the private maintainer list.
-* When a project has no maintainers the InstructLab org maintainers become responsible for it and may archive the project or find new maintainers
-* When maintainers no longer maintain active projects due to project archival or removal, they become emeritus maintainers unless they join another InstructLab project as maintainers.
+Advancement to Project Maintainer position, removal, and duties are detailed in the [Contributor Ladder](/CONTRIBUTOR_LADDER.md).  The [current maintainers](/MAINTAINERS.md) are listed in this repository.
 
 ## Decision Making at the InstructLab org level
 
@@ -81,21 +84,26 @@ The default decision making process is [lazy-consensus](http://communitymgt.wiki
 
 When a consensus cannot be found a maintainer can call for a [majority](https://en.wikipedia.org/wiki/Majority) vote on a decision.
 
-Many of the day-to-day project maintenance can be done by a lazy consensus model. But the following items must be called to vote:
+Many of the day-to-day project maintenance can be done by a lazy consensus model. But the following items must be called to vote of the appropriate body:
 
-* Enforcing a CoC violation (super majority)
+* Appointing or removing a member of the Code of Conduct Committee (super majority)
+* Carrying out Code of Conduct decisions requiring severe censure (majority)
 * Removing a maintainer for any reason other than inactivity (super majority)
 * Changing the governance rules (this document) (super majority)
 * Licensing and intellectual property changes (including new logos, wordmarks) (simple majority)
-* Adding, archiving, or removing subprojects (simple majority)
+* Adding, archiving, or removing projects (simple majority)
 
 Other decisions may, but do not need to be, called out and put up for decision on the **TODO: InstructLab mailing list** at any time and by anyone. By default, any decisions called to a vote will be for a _simple majority_ vote.
 
 ## Code of Conduct
 
-The code of conduct is overseen by the InstructLab project maintainers. Possible code of conduct violations should be emailed to the project maintainers at **TODO: InstructLab mailing list**.
+InstructLab's [Code of Conduct] is enforced by the Code of Conduct Committee (CoCC).  This committee will be appointed and removed by the Oversight Committee, or by the Project Maintainers before the OC is created, using a supermajority vote.  
 
-If the possible violation is against one of the project maintainers that member will be recused from voting on the issue.
+The CoCC is responsible for investigating, evaluating, and recommending remedies for substantiated Code of Conduct Incidents to the appropriate body. The CoCC will judge possible violations around principles of restorative justice rather than punishment. All teams within InstructLab are obligated to support the CoCC's recommendations on remedies.
+
+These are the current members of the [Code of Conduct Committee](/CoCC.md).
+
+Possible code of conduct violations should be emailed to the CoCC at **TODO: Private CoC mailing list**.
 
 ## DCO and Licenses
 
@@ -104,3 +112,7 @@ The following licenses and contributor agreements will be used for InstructLab p
 * [Apache 2.0](https://opensource.org/licenses/Apache-2.0) for code
 * [Creative Commons Attribution 4.0 International Public License](https://creativecommons.org/licenses/by/4.0/legalcode) for documentation
 * [Developer Certificate of Origin](https://developercertificate.org/) for new contributions
+
+## Modifications to this Governance
+
+This governance may be modified by a super-majority of the Oversight Committee, or by a super-majority of all Project Maintainers.


### PR DESCRIPTION
# Major changes

After a discussion with Martin Hickey, attached is a major revision of the draft governance which does two major changes:

1. Delays creating the org-wide leadership until we need it
2. Creates an independent Code of Conduct Committee

The reason for (1) is that currently half the Project Maintainers would be doubling up as org maintainers, increasing the amount of contributor overhead we have at a time when we don't really need it.  Right now, the collected Project Maintainers are perfectly capable of making decisions as a group; it's only later that we'll need another body.  This postpones some of the bureaucracy until a time when we're better equipped to deal with it, like in say 6 months.  Kubernetes didn't add a Steering Committee until the project was 2 years old.

(2) is because based on my experience with the CNCF and Kubernetes it's very hard for the maintainers to handle CoC complaints.

# Minor changes

In addition to those, I've made the following minor changes based on my experience with the Helm governance in practice:

* renamed the Org Maintainers as the Oversight Committee, which is more appropriate to the role and the fact that it's a limited number
* made the appointment of the Oversight Committee annual rather than being for life
* cleared up a lot of language around InstructLab as a whole vs. each Project
* removed text from GOVERNANCE that conflicted with text in CONTRIBUTOR LADDER around selection of maintainers, etc.
* genericized the stepping down process to cover all contributors with named roles, not just maintainers
* made the duties of the Code of Conduct Committee more clear
* lots of miscellaneous making the names used in one document match the names used in another

## Unresolved Issues

The current governance has two Projects and two Services: CLI, Taxonomy, Documentation, and Public Taxonomy(????).  Whereas the Maintainers file has CLI, Taxonomy, and Community.  What should the actual subprojects (Projects) be?  