### PR TITLE
Add CC-BY-SA-4.0 to docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ For this project, unless the file says otherwise, or unless the attributed sourc
 - CC0
 - CDLA-Permissive
 - CC-BY-4.0
+- CC-BY-SA-4.0
 - Apache 2.0
 - MIT
 Any third party content contributed to this project undergoes modifications in order to formulate it in the templated format required for submission to this project.


### PR DESCRIPTION
The Creative Commons Attribution-ShareAlike 4.0 license used by Wikipedia is distinct from Creative Commons Attribution 4.0 (CC-BY-4.0): add it to the list of included license types in README.md.