### PR TITLE
MAINTAINERS: List all teams

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -79,6 +79,14 @@
 - [JoeAldinger](https://github.com/JoeAldinger)
 
 
+## Enhancements
+
+### Enhancements Triagers
+
+- [russellb](https://github.com/russellb)
+- [nathan-weinberg](https://github.com/nathan-weinberg)
+
+
 ## InstructLabBot
 
 ### InstructLab Bot Maintainers
@@ -87,6 +95,22 @@
 - [nerdalert](https://github.com/nerdalert)
 - [vishnoianil](https://github.com/vishnoianil)
 - [dave-tucker](https://github.com/dave-tucker)
+
+
+### InstructLab Bot Triagers
+
+- [russellb](https://github.com/russellb)
+- [cdoern](https://github.com/cdoern)
+- [nathan-weinberg](https://github.com/nathan-weinberg)
+- [alinaryan](https://github.com/alinaryan)
+
+
+## Schema
+
+### Schema Maintainers
+
+- [bjhargrave](https://github.com/bjhargrave)
+- [jjasghar](https://github.com/jjasghar)
 
 
 ## Taxonomy
@@ -148,6 +172,15 @@
 - [abrahamdaniels](https://github.com/abrahamdaniels)
 - [caradelia](https://github.com/caradelia)
 - [katesoule](https://github.com/katesoule)
+
+
+## Website
+
+### Website Maintainers
+
+- [joesepi](https://github.com/joesepi)
+- [sstano](https://github.com/sstano)
+- [connor-leech](https://github.com/connor-leech)
 
 
 ## Admins

--- a/tools/maintainers/maintainers.py
+++ b/tools/maintainers/maintainers.py
@@ -10,7 +10,7 @@ import yaml
 
 
 def get_team_members(team_slug):
-    org = 'instruct-lab'
+    org = 'instructlab'
     result = subprocess.run(['gh', 'api', '--method', 'GET',
                              f'/orgs/{org}/teams/{team_slug}/members'],
                              stdout=subprocess.PIPE)

--- a/tools/maintainers/teams.yaml
+++ b/tools/maintainers/teams.yaml
@@ -14,9 +14,19 @@ Community:
 - name: Community Maintainers
   slug: community-maintainers
 
+Enhancements:
+- name: Enhancements Triagers
+  slug: enhancements-triagers
+
 InstructLabBot:
 - name: InstructLab Bot Maintainers
   slug: instruct-lab-bot-maintainers
+- name: InstructLab Bot Triagers
+  slug: instruct-lab-bot-triagers
+
+Schema:
+- name: Schema Maintainers
+  slug: schema-maintainers
 
 Taxonomy:
 - name: Taxonomy Approvers
@@ -25,6 +35,10 @@ Taxonomy:
   slug: taxonomy-maintainers
 - name: Taxonomy Triagers
   slug: taxonomy-triagers
+
+Website:
+- name: Website Maintainers
+  slug: website-maintainers
 
 Admins:
 - name: Org Maintainers


### PR DESCRIPTION

commit 0b505b082daa206939b307a1cebea47c5299604c
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Apr 17 15:23:20 2024 -0400

    MAINTAINERS: Add all teams
    
    Some teams that exist in GitHub were not captured here. Add the rest
    so this list is complete.
    
    Also fix the script to account for the org name change.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
