### PR TITLE
change security.md to add temporary reporting email alias

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ The InstructLab team and community take security bugs seriously. We appreciate y
 
 # Reporting a Vulnerability
 
-If you think you've identified a security issue in an InstructLab project repository, please DO NOT report the issue publicly via the Github issue tracker, Slack Workspace, etc. 
+If you think you've identified a security issue in an InstructLab project repository, please DO NOT report the issue publicly via the GitHub issue tracker, Slack Workspace, etc. 
 
 Instead, send an email with as many details as possible to [instructlab-sec@osci.io](mailto:instructlab-sec@osci.io). This is a private mailing list for the core maintainers.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,19 @@
-# Security Policy
+# Security and Disclosure Information Policy for the InstructLab Project
 
 The InstructLab team and community take security bugs seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
 
-To report a security issue, see [Security Advisories](https://github.com/instructlab/community/security/advisories).
+# Reporting a Vulnerability
 
-The InstructLab team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+If you think you've identified a security issue in a Containers project, please DO NOT report the issue publicly via the Github issue tracker, Slack Workspace, etc. 
 
+Instead, send an email with as many details as possible to [instructlab-sec@osci.io](mailto:instructlab-sec@osci.io). This is a private mailing list for the core maintainers.
+
+Please do not create a public issue.
+
+# Security Vulnerability Response
+
+Each report is acknowledged and analyzed by the core maintainers within 3 working days.
+
+Any vulnerability information shared with core maintainers stays within the InstructLab project and will not be disseminated to other projects unless it is necessary to get the issue fixed.
+
+After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ The InstructLab team and community take security bugs seriously. We appreciate y
 
 # Reporting a Vulnerability
 
-If you think you've identified a security issue in a Containers project, please DO NOT report the issue publicly via the Github issue tracker, Slack Workspace, etc. 
+If you think you've identified a security issue in an InstructLab project repository, please DO NOT report the issue publicly via the Github issue tracker, Slack Workspace, etc. 
 
 Instead, send an email with as many details as possible to [instructlab-sec@osci.io](mailto:instructlab-sec@osci.io). This is a private mailing list for the core maintainers.
 


### PR DESCRIPTION
updated page using https://github.com/containers/common/blob/main/SECURITY.md as a template