### PR TITLE
feat: always sort team members alphabetically

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,20 +6,20 @@
 
 Team which has full maintainer access to the Backend repositories
 
-- [russellb](https://github.com/russellb)
-- [anik120](https://github.com/anik120)
-- [alimaredia](https://github.com/alimaredia)
-- [xukai92](https://github.com/xukai92)
-- [abhi1092](https://github.com/abhi1092)
-- [jaideepr97](https://github.com/jaideepr97)
-- [cdoern](https://github.com/cdoern)
 - [aakankshaduggal](https://github.com/aakankshaduggal)
-- [nathan-weinberg](https://github.com/nathan-weinberg)
-- [oindrillac](https://github.com/oindrillac)
+- [abhi1092](https://github.com/abhi1092)
+- [alimaredia](https://github.com/alimaredia)
+- [alinaryan](https://github.com/alinaryan)
+- [anik120](https://github.com/anik120)
+- [cdoern](https://github.com/cdoern)
+- [jaideepr97](https://github.com/jaideepr97)
 - [JamesKunstle](https://github.com/JamesKunstle)
 - [khaledsulayman](https://github.com/khaledsulayman)
-- [alinaryan](https://github.com/alinaryan)
+- [nathan-weinberg](https://github.com/nathan-weinberg)
+- [oindrillac](https://github.com/oindrillac)
 - [RobotSail](https://github.com/RobotSail)
+- [russellb](https://github.com/russellb)
+- [xukai92](https://github.com/xukai92)
 
 
 ## CLI
@@ -28,42 +28,42 @@ Team which has full maintainer access to the Backend repositories
 
 Team which has full maintainer access to the CLI repository
 
-- [joesepi](https://github.com/joesepi)
-- [bjhargrave](https://github.com/bjhargrave)
-- [russellb](https://github.com/russellb)
-- [soltysh](https://github.com/soltysh)
-- [mairin](https://github.com/mairin)
 - [afrittoli](https://github.com/afrittoli)
-- [anik120](https://github.com/anik120)
 - [alimaredia](https://github.com/alimaredia)
-- [rawkintrevo](https://github.com/rawkintrevo)
-- [xukai92](https://github.com/xukai92)
-- [spzala](https://github.com/spzala)
+- [anik120](https://github.com/anik120)
+- [bjhargrave](https://github.com/bjhargrave)
+- [cdoern](https://github.com/cdoern)
+- [hickeyma](https://github.com/hickeyma)
+- [joesepi](https://github.com/joesepi)
+- [kelbrown20](https://github.com/kelbrown20)
+- [mairin](https://github.com/mairin)
 - [markstur](https://github.com/markstur)
 - [mrutkows](https://github.com/mrutkows)
-- [Tomcli](https://github.com/Tomcli)
-- [hickeyma](https://github.com/hickeyma)
-- [cdoern](https://github.com/cdoern)
 - [nathan-weinberg](https://github.com/nathan-weinberg)
-- [kelbrown20](https://github.com/kelbrown20)
+- [rawkintrevo](https://github.com/rawkintrevo)
+- [russellb](https://github.com/russellb)
+- [soltysh](https://github.com/soltysh)
+- [spzala](https://github.com/spzala)
+- [Tomcli](https://github.com/Tomcli)
+- [xukai92](https://github.com/xukai92)
 
 
 ### CLI Triagers
 
 Team that can manage Issues and Pull Requests but cannot merge code to the CLI repository
 
-- [mairin](https://github.com/mairin)
-- [cybette](https://github.com/cybette)
-- [anik120](https://github.com/anik120)
-- [alimaredia](https://github.com/alimaredia)
-- [rawkintrevo](https://github.com/rawkintrevo)
+- [aakankshaduggal](https://github.com/aakankshaduggal)
 - [abhi1092](https://github.com/abhi1092)
+- [alimaredia](https://github.com/alimaredia)
+- [anik120](https://github.com/anik120)
+- [cybette](https://github.com/cybette)
 - [hickeyma](https://github.com/hickeyma)
 - [jaideepr97](https://github.com/jaideepr97)
-- [aakankshaduggal](https://github.com/aakankshaduggal)
-- [oindrillac](https://github.com/oindrillac)
 - [JamesKunstle](https://github.com/JamesKunstle)
 - [juliadenham](https://github.com/juliadenham)
+- [mairin](https://github.com/mairin)
+- [oindrillac](https://github.com/oindrillac)
+- [rawkintrevo](https://github.com/rawkintrevo)
 - [tharapalanivel](https://github.com/tharapalanivel)
 
 
@@ -73,18 +73,18 @@ Team that can manage Issues and Pull Requests but cannot merge code to the CLI r
 
 Team which has full maintainer access to the Community repository
 
-- [jberkus](https://github.com/jberkus)
-- [joesepi](https://github.com/joesepi)
 - [bjhargrave](https://github.com/bjhargrave)
-- [jjasghar](https://github.com/jjasghar)
-- [cybette](https://github.com/cybette)
+- [caradelia](https://github.com/caradelia)
 - [ckadner](https://github.com/ckadner)
+- [cybette](https://github.com/cybette)
 - [hickeyma](https://github.com/hickeyma)
+- [jberkus](https://github.com/jberkus)
+- [jjasghar](https://github.com/jjasghar)
+- [JoeAldinger](https://github.com/JoeAldinger)
+- [joesepi](https://github.com/joesepi)
+- [kelbrown20](https://github.com/kelbrown20)
 - [mingxzhao](https://github.com/mingxzhao)
 - [stevsmit](https://github.com/stevsmit)
-- [caradelia](https://github.com/caradelia)
-- [kelbrown20](https://github.com/kelbrown20)
-- [JoeAldinger](https://github.com/JoeAldinger)
 
 
 ## Enhancements
@@ -93,8 +93,8 @@ Team which has full maintainer access to the Community repository
 
 Team which has full maintainer access to the Enhancements repository
 
-- [russellb](https://github.com/russellb)
 - [nathan-weinberg](https://github.com/nathan-weinberg)
+- [russellb](https://github.com/russellb)
 
 
 ## InstructLabBot
@@ -103,20 +103,20 @@ Team which has full maintainer access to the Enhancements repository
 
 Team which has full maintainer access to the InstructLab Bot repository
 
-- [russellb](https://github.com/russellb)
-- [nerdalert](https://github.com/nerdalert)
-- [vishnoianil](https://github.com/vishnoianil)
 - [dave-tucker](https://github.com/dave-tucker)
+- [nerdalert](https://github.com/nerdalert)
+- [russellb](https://github.com/russellb)
+- [vishnoianil](https://github.com/vishnoianil)
 
 
 ### InstructLab Bot Triagers
 
 Team that can manage Issues and Pull Requests but cannot merge code to the InstructLab Bot repository
 
-- [russellb](https://github.com/russellb)
+- [alinaryan](https://github.com/alinaryan)
 - [cdoern](https://github.com/cdoern)
 - [nathan-weinberg](https://github.com/nathan-weinberg)
-- [alinaryan](https://github.com/alinaryan)
+- [russellb](https://github.com/russellb)
 
 
 ## Schema
@@ -135,65 +135,65 @@ Team which has full maintainer access to the Schema repository
 
 Team which has approval permissions to the Taxonomy repository
 
-- [obuzek](https://github.com/obuzek)
-- [bjhargrave](https://github.com/bjhargrave)
-- [akashgit](https://github.com/akashgit)
-- [jjasghar](https://github.com/jjasghar)
-- [jeremyeder](https://github.com/jeremyeder)
-- [xukai92](https://github.com/xukai92)
-- [abhi1092](https://github.com/abhi1092)
 - [aakankshaduggal](https://github.com/aakankshaduggal)
+- [abhi1092](https://github.com/abhi1092)
+- [akashgit](https://github.com/akashgit)
+- [bjhargrave](https://github.com/bjhargrave)
+- [darrellreimer](https://github.com/darrellreimer)
+- [jeremyeder](https://github.com/jeremyeder)
+- [jjasghar](https://github.com/jjasghar)
+- [mingxzhao](https://github.com/mingxzhao)
+- [obuzek](https://github.com/obuzek)
 - [oindrillac](https://github.com/oindrillac)
 - [shivchander](https://github.com/shivchander)
-- [darrellreimer](https://github.com/darrellreimer)
-- [mingxzhao](https://github.com/mingxzhao)
+- [xukai92](https://github.com/xukai92)
 
 
 ### Taxonomy Maintainers
 
 Team which has full maintainer access to the Taxonomy repository
 
-- [joesepi](https://github.com/joesepi)
-- [obuzek](https://github.com/obuzek)
 - [bjhargrave](https://github.com/bjhargrave)
-- [russellb](https://github.com/russellb)
-- [mairin](https://github.com/mairin)
-- [jjasghar](https://github.com/jjasghar)
-- [jeremyeder](https://github.com/jeremyeder)
-- [cybette](https://github.com/cybette)
-- [xukai92](https://github.com/xukai92)
-- [lehors](https://github.com/lehors)
-- [markstur](https://github.com/markstur)
-- [Tomcli](https://github.com/Tomcli)
-- [ckadner](https://github.com/ckadner)
-- [hickeyma](https://github.com/hickeyma)
-- [mingxzhao](https://github.com/mingxzhao)
-- [luke-inglis](https://github.com/luke-inglis)
 - [caradelia](https://github.com/caradelia)
-- [kelbrown20](https://github.com/kelbrown20)
+- [ckadner](https://github.com/ckadner)
+- [cybette](https://github.com/cybette)
+- [hickeyma](https://github.com/hickeyma)
+- [jeremyeder](https://github.com/jeremyeder)
+- [jjasghar](https://github.com/jjasghar)
+- [joesepi](https://github.com/joesepi)
 - [juliadenham](https://github.com/juliadenham)
+- [kelbrown20](https://github.com/kelbrown20)
+- [lehors](https://github.com/lehors)
+- [luke-inglis](https://github.com/luke-inglis)
+- [mairin](https://github.com/mairin)
+- [markstur](https://github.com/markstur)
+- [mingxzhao](https://github.com/mingxzhao)
+- [obuzek](https://github.com/obuzek)
+- [russellb](https://github.com/russellb)
+- [Tomcli](https://github.com/Tomcli)
+- [xukai92](https://github.com/xukai92)
 
 
 ### Taxonomy Triagers
 
 Team that can manage Issues and Pull Requests but cannot merge code to the Taxonomy repository
 
-- [joesepi](https://github.com/joesepi)
-- [lhawthorn](https://github.com/lhawthorn)
-- [mairin](https://github.com/mairin)
-- [jjasghar](https://github.com/jjasghar)
-- [cybette](https://github.com/cybette)
-- [xukai92](https://github.com/xukai92)
-- [lehors](https://github.com/lehors)
-- [markstur](https://github.com/markstur)
-- [ckadner](https://github.com/ckadner)
-- [hickeyma](https://github.com/hickeyma)
-- [oindrillac](https://github.com/oindrillac)
-- [spacew](https://github.com/spacew)
-- [mingxzhao](https://github.com/mingxzhao)
 - [abrahamdaniels](https://github.com/abrahamdaniels)
 - [caradelia](https://github.com/caradelia)
+- [ckadner](https://github.com/ckadner)
+- [cybette](https://github.com/cybette)
+- [hickeyma](https://github.com/hickeyma)
+- [jjasghar](https://github.com/jjasghar)
+- [joesepi](https://github.com/joesepi)
 - [katesoule](https://github.com/katesoule)
+- [lehors](https://github.com/lehors)
+- [lhawthorn](https://github.com/lhawthorn)
+- [mairin](https://github.com/mairin)
+- [markstur](https://github.com/markstur)
+- [mingxzhao](https://github.com/mingxzhao)
+- [oindrillac](https://github.com/oindrillac)
+- [spacew](https://github.com/spacew)
+- [xukai92](https://github.com/xukai92)
 
 
 ## Website
@@ -202,9 +202,9 @@ Team that can manage Issues and Pull Requests but cannot merge code to the Taxon
 
 Team which has full maintainer access to the Website repository
 
+- [connor-leech](https://github.com/connor-leech)
 - [joesepi](https://github.com/joesepi)
 - [sstano](https://github.com/sstano)
-- [connor-leech](https://github.com/connor-leech)
 
 
 ## Admins
@@ -213,34 +213,34 @@ Team which has full maintainer access to the Website repository
 
 Team which has full maintainer access to the InstructLab organization
 
-- [matthicksj](https://github.com/matthicksj)
-- [joesepi](https://github.com/joesepi)
-- [russellb](https://github.com/russellb)
-- [danmcp](https://github.com/danmcp)
-- [lhawthorn](https://github.com/lhawthorn)
-- [akashgit](https://github.com/akashgit)
-- [mairin](https://github.com/mairin)
-- [jjasghar](https://github.com/jjasghar)
-- [jeremyeder](https://github.com/jeremyeder)
-- [alimaredia](https://github.com/alimaredia)
-- [xukai92](https://github.com/xukai92)
-- [markstur](https://github.com/markstur)
-- [aldopareja](https://github.com/aldopareja)
-- [hickeyma](https://github.com/hickeyma)
-- [jaideepr97](https://github.com/jaideepr97)
-- [cdoern](https://github.com/cdoern)
 - [aakankshaduggal](https://github.com/aakankshaduggal)
-- [nathan-weinberg](https://github.com/nathan-weinberg)
-- [oindrillac](https://github.com/oindrillac)
-- [shivchander](https://github.com/shivchander)
-- [darrellreimer](https://github.com/darrellreimer)
-- [JamesKunstle](https://github.com/JamesKunstle)
-- [khaledsulayman](https://github.com/khaledsulayman)
-- [luke-inglis](https://github.com/luke-inglis)
+- [akashgit](https://github.com/akashgit)
+- [aldopareja](https://github.com/aldopareja)
+- [alimaredia](https://github.com/alimaredia)
 - [alinaryan](https://github.com/alinaryan)
 - [caradelia](https://github.com/caradelia)
-- [kelbrown20](https://github.com/kelbrown20)
+- [cdoern](https://github.com/cdoern)
+- [danmcp](https://github.com/danmcp)
+- [darrellreimer](https://github.com/darrellreimer)
+- [hickeyma](https://github.com/hickeyma)
+- [jaideepr97](https://github.com/jaideepr97)
+- [JamesKunstle](https://github.com/JamesKunstle)
+- [jeremyeder](https://github.com/jeremyeder)
+- [jjasghar](https://github.com/jjasghar)
+- [joesepi](https://github.com/joesepi)
 - [juliadenham](https://github.com/juliadenham)
+- [kelbrown20](https://github.com/kelbrown20)
+- [khaledsulayman](https://github.com/khaledsulayman)
+- [lhawthorn](https://github.com/lhawthorn)
+- [luke-inglis](https://github.com/luke-inglis)
+- [mairin](https://github.com/mairin)
+- [markstur](https://github.com/markstur)
+- [matthicksj](https://github.com/matthicksj)
+- [nathan-weinberg](https://github.com/nathan-weinberg)
+- [oindrillac](https://github.com/oindrillac)
 - [RobotSail](https://github.com/RobotSail)
+- [russellb](https://github.com/russellb)
+- [shivchander](https://github.com/shivchander)
+- [xukai92](https://github.com/xukai92)
 
 

--- a/tools/maintainers/maintainers.py
+++ b/tools/maintainers/maintainers.py
@@ -37,7 +37,8 @@ def main(argv=None):
                 print("### %s\n" % t["name"])
                 print("%s\n" % t["desc"])
                 members = get_team_members(t["slug"])
-                for m in members:
+                members_sorted = sorted(members, key=lambda d: d['login'].lower())
+                for m in members_sorted:
                     print("- [%s](https://github.com/%s)" % (m["login"], m["login"]))
                 print("\n")
 


### PR DESCRIPTION
Very minor but it occurred to me as long as we are doing this programmatically we may as well sort the team members alphabetically by GitHub login