### PR TITLE
Fix broken references to CLI repo due to rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ Please report unacceptable behavior to one of the Code of Conduct [Committee mem
 
 In addition to this repository, InstructLab has two related repositories:
 
-* [`ilab` command-line interface (CLI) tool](https://github.com/instructlab/cli). This repository is responsible for the `ilab` command-line interface (CLI) tool.
-* [taxonomoy tree](https://github.com/instructlab/taxonomy). This repository is responsible for the taxonomy tree that allows you to create models tuned with your data.
+* [`ilab` command-line interface (CLI) tool](https://github.com/instructlab/instructlab). This repository is responsible for the `ilab` command-line interface (CLI) tool.
+* [taxonomy tree](https://github.com/instructlab/taxonomy). This repository is responsible for the taxonomy tree that allows you to create models tuned with your data.
 
 The following sections provide a general overview for contributing to any of the InstructLab repositories.
 
@@ -31,9 +31,9 @@ To contribute code or documentation, please submit a pull request to the relevan
 
 ### ilab command-line interface (CLI) tool repository
 
-We welcome contributions in the form of pull requests for documentation updates, code contributions and more. Prior to contribution, users should acquaint themselves with the [`ilab` CLI repository contribution guide](https://github.com/instructlab/cli/blob/main/CONTRIBUTING/CONTRIBUTING.md).
+We welcome contributions in the form of pull requests for documentation updates, code contributions and more. Prior to contribution, users should acquaint themselves with the [`ilab` CLI repository contribution guide](https://github.com/instructlab/instructlab/blob/main/CONTRIBUTING/CONTRIBUTING.md).
 
-To submit a pull request to the `ilab` CLI tool repository, see the [pull request page](https://github.com/instructlab/cli/pulls).
+To submit a pull request to the `ilab` CLI tool repository, see the [pull request page](https://github.com/instructlab/instructlab/pulls).
 
 ### Taxonomy repository
 
@@ -50,7 +50,7 @@ We welcome contributions in the form of pull requests for documentation. To subm
 The InstructLab project uses the _Fork and Pull_ model for contribution that is common in many open source repositories; this entails multiple steps, including forking and cloning the repository, creating a _pull request_, or PR, and more. For details on this process, check out [The GitHub Workflow
 Guide](https://github.com/kubernetes/community/blob/master/contributors/guide/github-workflow.md) from Kubernetes. If you are already familiar with this process, the taxonomy repository provides [detailed contribution instructions](https://github.com/instructlab/taxonomy/blob/main/README.md#detailed-contribution-instructions) as an example.
 
-After you have forked and cloned the repository, you can start the contribution process by looking at the issue trackers of the [community repository](https://github.com/instructlab/community/pulls), [CLI repository](https://github.com/instructlab/cli/issues), or the [taxonomy repository](https://github.com/instructlab/taxonomy/issues). You can then pick up an issue by leaving a comment on said issue, and address the issue in a pull request (PR). Prior to submission, make sure that your changes pass formatting, linting, and unit tests. Additionally, all PRs must agree to the terms of [Developer Certificate of Origin (DCO)](https://developercertificate.org/) by signing off your commits. Only PRs with commits signed off are accepted. If you didn't sign off your commits before creating the pull request, no worries, you can fix that after the fact. For more information about this process, see [Developer Certificate of Origin (DCO)](#DCO).
+After you have forked and cloned the repository, you can start the contribution process by looking at the issue trackers of the [community repository](https://github.com/instructlab/community/pulls), [CLI repository](https://github.com/instructlab/instructlab/issues), or the [taxonomy repository](https://github.com/instructlab/taxonomy/issues). You can then pick up an issue by leaving a comment on said issue, and address the issue in a pull request (PR). Prior to submission, make sure that your changes pass formatting, linting, and unit tests. Additionally, all PRs must agree to the terms of [Developer Certificate of Origin (DCO)](https://developercertificate.org/) by signing off your commits. Only PRs with commits signed off are accepted. If you didn't sign off your commits before creating the pull request, no worries, you can fix that after the fact. For more information about this process, see [Developer Certificate of Origin (DCO)](#DCO).
 
 Then, you can submit the PR to be reviewed. In general, we follow the standard [GitHub pull request](https://help.github.com/en/articles/about-pull-requests) process. Follow the provided template on your PR to include details about your pull request for the maintainers.
 
@@ -74,7 +74,7 @@ For a list of the maintainers and triagers, see the [MAINTAINERS.md](MAINTAINERS
 
 To propose a new feature, it's best to raise an issue in the appropriate repository:
 
-- [CLI repository](https://github.com/instructlab/cli/issues)
+- [CLI repository](https://github.com/instructlab/instructlab/issues)
 - [taxonomy repository](https://github.com/instructlab/taxonomy/issues)
 
 This way, features can be discussed with the project maintainers, ensuring that your time is not wasted working on a feature that the project developers will not accept into the codebase.
@@ -135,9 +135,9 @@ The following resources include additional information about each repository, su
 
 ### ilab CLI tool additional resources
 
-- [`ilab` CLI tool README.md](https://github.com/instructlab/cli/blob/main/README.md#instructlab--ilab). This resources provides information about the `ilab` CLI tool, including an overview, getting started, training the model, submitting a pull request, etc.
+- [`ilab` CLI tool README.md](https://github.com/instructlab/instructlab/blob/main/README.md#instructlab--ilab). This resources provides information about the `ilab` CLI tool, including an overview, getting started, training the model, submitting a pull request, etc.
 
-- [`ilab` CLI tool CONTRIBUTING.md](https://github.com/instructlab/cli/blob/main/CONTRIBUTING/CONTRIBUTING.md#contributing). This resources provides information about contributing to the `ilab` CLI tool repository, reporting bugs, testing, coding styles, etc.
+- [`ilab` CLI tool CONTRIBUTING.md](https://github.com/instructlab/instructlab/blob/main/CONTRIBUTING/CONTRIBUTING.md#contributing). This resources provides information about contributing to the `ilab` CLI tool repository, reporting bugs, testing, coding styles, etc.
 
 ### Taxonomy additional resources
 

--- a/CONTRIBUTOR_ROLES.md
+++ b/CONTRIBUTOR_ROLES.md
@@ -2,8 +2,8 @@
 
 InstructLab is made up of several projects that are defined as codebases and services with different release cycles. Collectively, these enable large-model development. Currently, these projects include the following:
 
-* [`ilab` command-line interface (CLI) tool](https://github.com/instructlab/cli). This repository is responsible for the the `ilab` CLI tool. 
-* [taxonomoy tree](https://github.com/instructlab/taxonomy). This repository is responsible for the taxonomy tree that allows you to create models tuned with your data. 
+* [`ilab` command-line interface (CLI) tool](https://github.com/instructlab/instructlab). This repository is responsible for the the `ilab` CLI tool. 
+* [taxonomy tree](https://github.com/instructlab/taxonomy). This repository is responsible for the taxonomy tree that allows you to create models tuned with your data. 
 
 This document outlines a core number of contributor roles for InstructLab projects, such as _Member_, _Triager_, _Reviewer_, and _Maintainer_. In the future, an _Oversight Committee_ will be formed, which will serve to supervise the overall InstructLab project and its health. Using transparent criteria, the journey between roles is based on individual participation.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -47,7 +47,7 @@ This page serves as a comprehensive FAQ for the InstructLab project, detailing h
 There are currently three repositories that contain documentation crucial to getting users starting with the project:
 
 * [Community](https://github.com/instruct-lab/community) This repository shares InstructLab's activity and collaboration details across the community and include the most current information about the project. It should be approached as the primary repository for getting started, and contains procedures and links to relevant information to make the process as simple as possible.
-* [`ilab` command-line interface (CLI) tool](https://github.com/instruct-lab/cli). This repository is responsible for the `ilab` CLI tool. It provides information about how to download the `ilab` CLI, how to contribute to the `ilab` CLI tool, among others.
+* [`ilab` command-line interface (CLI) tool](https://github.com/instruct-lab/instructlab). This repository is responsible for the `ilab` CLI tool. It provides information about how to download the `ilab` CLI, how to contribute to the `ilab` CLI tool, among others.
 * [taxonomy tree](https://github.com/instruct-lab/taxonomy). This repository is responsible for the taxonomy tree that allows you to create models tuned with your data. It provides information about what skills and knowledge are, how to create a pull request to contribute to the AI model, and expectations for pull request review. 
 
 As this project grows, documentation and its organization will change. Members of this project will be made aware of significant changes and updates made to documentation.
@@ -94,7 +94,7 @@ When you're ready to start contributing, you can follow the [Getting started](ht
 
 ### I'm having problems with the `ilab` CLI tool. What should I do?
 
-A list of common problems associated with downloading the `ilab` CLI tool can be found [in the CLI repository's discussion board](https://github.com/instruct-lab/cli/discussions).
+A list of common problems associated with downloading the `ilab` CLI tool can be found [in the CLI repository's discussion board](https://github.com/instruct-lab/instructlab/discussions).
 
 ### Why should I contribute?
 
@@ -229,7 +229,7 @@ Additional resources, including the Code of Conduct, Code of Conduct Committee m
 
 [InstructLab Taxonomy Repository](https://github.com/instructlab/taxonomy)
 
-[InstructLab CLI Repository](https://github.com/instructlab/cli)
+[InstructLab CLI Repository](https://github.com/instructlab/instructlab)
 
 [InstructLab Community Repository](https://github.com/instructlab/community)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The mission of the InstructLab (**L**arge-scale **A**lignment for chat**B**ots) 
 
 InstructLab is made up of several projects that are defined as codebases and services with different release cycles. Collectively, these enable large-model development. This repository shares InstructLab's activity and collaboration details across the community and include the most current information about the project. Related repositories include the following:
 
-* [`ilab` command-line interface (CLI) tool](https://github.com/instructlab/cli). This repository is responsible for the `ilab` command-line interface (CLI) tool. 
+* [`ilab` command-line interface (CLI) tool](https://github.com/instructlab/instructlab). This repository is responsible for the `ilab` command-line interface (CLI) tool. 
 * [taxonomy tree](https://github.com/instructlab/taxonomy). This repository is responsible for the taxonomy tree that allows you to create models tuned with your data. 
 
 Contributing new features, resolving bugs and issues, and refining the documentation experience through pull requests are welcome. More information about contributing to the InstructLab Project, contributor roles, governance and legal, and licenses can be found in proceeding sections of this document.
@@ -31,7 +31,7 @@ The `ilab` tool allows you to interact with the IBM AI model `Merlinite`, contri
 
 > **Note:** Before proceeding, it might be beneficial to check out the [Contributing](https://github.com/instruct-lab/community/blob/main/CONTRIBUTING.md) guide for an overview of contributing practices and expectations. Additionally, you should consider joining the [InstructLab community Slack channel](https://github.com/instructlab/community/blob/main/InstructLabSlackGuide.md).
 
-1. Navigate to the `ilab` CLI repository and follow the instructions in the [README.md](https://github.com/instructlab/cli/blob/main/README.md). The README.md instructs you on how to perform the following: 
+1. Navigate to the `ilab` CLI repository and follow the instructions in the [README.md](https://github.com/instructlab/instructlab/blob/main/README.md). The README.md instructs you on how to perform the following: 
 
     a. In the [Getting started](https://github.com/instruct-lab/cli/blob/main/README.md#-getting-started) section of the README.md file, you can install the `ilab` tool, set up your local environment, and download the IBM `Merlinite` AI model. If you run into any issues, you can find many solutions in the [in the CLI repository's discussion board](https://github.com/instruct-lab/cli/discussions).
 
@@ -39,7 +39,7 @@ The `ilab` tool allows you to interact with the IBM AI model `Merlinite`, contri
 
     c. In your local taxonomy repository, generated after the [Initialize lab](https://github.com/instructlab/instructlab/blob/main/README.md#-installing-ilab) step, navigate to the path that you want to add information to. You can see a flow chart of the paths in this file [taxonomy_diagram](https://github.com/instruct-lab/taxonomy/blob/main/docs/taxonomy_diagram.png). Create a `qna.yaml` file in that path with your contributions. 
 
-    d. [Serve and train the model](https://github.com/instructlab/cli/blob/main/README.md#-train-the-model) with your contributions to see if the model can answer questions more accurately. 
+    d. [Serve and train the model](https://github.com/instructlab/instructlab/blob/main/README.md#-train-the-model) with your contributions to see if the model can answer questions more accurately. 
 
     e. Congratulations! You trained an AI model locally! 
 
@@ -67,7 +67,7 @@ To contribute code or documentation, please submit a pull request to the relevan
 
 - For more information about general contribution practices, see the [Contributing](https://github.com/instructlab/community/blob/main/CONTRIBUTING.md) guide.
 - For more information about contributing to the taxonomy repository, see the [Taxonomy's contribution guide](https://github.com/instructlab/taxonomy/blob/main/CONTRIBUTING.md).
-- For more information about contributing to the CLI repository, see the [CLI's contribution guide](https://github.com/instructlab/cli/blob/main/CONTRIBUTING/CONTRIBUTING.md).
+- For more information about contributing to the CLI repository, see the [CLI's contribution guide](https://github.com/instructlab/instructlab/blob/main/CONTRIBUTING/CONTRIBUTING.md).
 
 ### Contributor roles
 

--- a/governance.md
+++ b/governance.md
@@ -6,8 +6,8 @@ The following document outlines how the InstructLab project governance operates.
 
 InstructLab is made up of several projects that are defined as codebases and services with different release cycles. Collectively, these enable large-model development. Currently, these projects include the following:
 
-* [`ilab` command-line interface (CLI) tool](https://github.com/instructlab/cli). This repository is responsible for the `ilab` command-line interface (CLI) tool. 
-* [taxonomoy tree](https://github.com/instructlab/taxonomy). This repository is responsible for the taxonomy tree that allows you to create models tuned with your data. 
+* [`ilab` command-line interface (CLI) tool](https://github.com/instructlab/instructlab). This repository is responsible for the `ilab` command-line interface (CLI) tool. 
+* [taxonomy tree](https://github.com/instructlab/taxonomy). This repository is responsible for the taxonomy tree that allows you to create models tuned with your data. 
 
 ## Governance Structure and Roadmap
 


### PR DESCRIPTION
Links are not redirecting for me