### PR TITLE
Reflect the bootstrapping oversight committee

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -9,6 +9,7 @@ Acknowledgements
 Adminstrators
 akashgit
 al
+aldopareja
 alimaredia
 Alina
 alinaryan
@@ -47,6 +48,7 @@ Conala
 Corbett
 curation
 cybette
+danmcp
 darrellreimer
 Dataset
 datasets

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,6 +2,20 @@
 
 *To update see [tools/maintainers/README.md](tools/maintainers/README.md)*
 
+## InstructLab
+
+### Oversight Committee
+
+The project-wide oversight committee
+
+- [aldopareja](https://github.com/aldopareja)
+- [danmcp](https://github.com/danmcp)
+- [jjasghar](https://github.com/jjasghar)
+- [lhawthorn](https://github.com/lhawthorn)
+- [mairin](https://github.com/mairin)
+- [russellb](https://github.com/russellb) - Chair
+- [xukai92](https://github.com/xukai92)
+
 ## CLI
 
 ### CLI Maintainers

--- a/governance.md
+++ b/governance.md
@@ -11,37 +11,35 @@ InstructLab is made up of several projects that are defined as codebases and ser
 
 ## Governance Structure and Roadmap
 
-The InstructLab Project will evolve into a two-level governance structure with an Oversight Committee and [Project Maintainers](https://github.com/instructlab/community/blob/main/MAINTAINERS.md).
+The InstructLab Project has a two-level governance structure with an Oversight Committee and [Project Maintainers](https://github.com/instructlab/community/blob/main/MAINTAINERS.md).
 
-At launch, the InstructLab Project will not have an Oversight Committee to avoid unnecessary overhead. After the majority of project Maintainers agree that the project has grown to the point where an Oversight Committee is necessary, project Maintainers will begin establishment. Until the Oversight Committee is constituted, duties of the Oversight Committee will be assumed by project Maintainers.
+Except where otherwise noted, decisions should always start at the most local level of project governance. For example, decisions that affect only one project, such as the taxonomy repository and not the `ilab` CLI tool, can happen within the taxonomy project. While communication between the different project teams is important as they are all interconnected, minor decisions do not need organization-wide consensus and can be moved forward at the project level.
 
-Except where otherwise noted, decisions should always start at the most local level of project governance. For example, decisions that affect only one project, such as the taxonomy repository and not the `ilab` CLI tool, can  happen within that project. While communication between the different project teams is important as they are all interconnected, minor decisions do not need organization-wide consensus and can be moved forward at the project level.
-
-Changes in maintainership and other governance are currently announced on the InstructLab community Slack channel. Directions to join the Slack channel can be found [here](https://github.com/instructlab/community/blob/main/InstructLabSlackGuide.md). In the future, a mailing list will be established.
+Changes in maintainership and other governance are currently announced on the InstructLab community Slack channel. Directions to join the Slack channel can be found [here](https://github.com/instructlab/community/blob/main/InstructLabSlackGuide.md). Changes are also announced to the [announce mailing list](https://github.com/instructlab/community/blob/main/Collaboration.md#email-lists).
 
 ## Project Maintainers overview
 
-Project Maintainers focus on a single codebase, a group of related codebases, a service (for example, a website), or project to support the other projects (such as marketing or community management).
+Project Maintainers focus on a single codebase, a group of related codebases, a service (for example, a website), or a project to support other projects (such as marketing or community management).
 
-Project Maintainers are responsible for activities surrounding the development and release of code, the operation of any services that they own, or the tasks needed to execute their project (for example, community management or setting up an event booth). Technical decisions for code resides with the project Maintainers unless there is a decision related to cross maintainer groups that cannot be resolved by those groups. Those cases can be escalated to the [organization Maintainers](https://github.com/instructlab/community/blob/main/MAINTAINERS.md).
-
-In some cases, groups of maintainers are responsible for more than one repository, such as `ilab` CLI tool maintainers managing the [taxonomy repository](https://github.com/instructlab/taxonomy).
+Project Maintainers are responsible for activities surrounding the development and release of code, the operation of any services that they own, or the tasks needed to execute their project (for example, community management or setting up an event booth). Technical decisions for code reside with the project Maintainers unless there is a decision related to multiple maintainer groups that cannot be resolved by those groups. Those cases can be escalated to the Oversight Committee.
 
 To be considered an _active project Maintainer_, it is required to be associated with at least one active, non-archived project. If only listed on archived projects, they become _emeritus Maintainers_ and are no longer eligible to become an organization Maintainer.
 
-Project Maintainers do not need to be software developers; however they must be substantial contributors. For example, if a repository is for documentation it would be appropriate for a project Maintainer to be an editor or technical writer.
+Project Maintainers do not need to be software developers; however, they must be substantial contributors. For example, if a repository is for documentation it would be appropriate for a project Maintainer to be an editor or technical writer.
 
 Advancement to the project Maintainer position, removal or stepping down, and duties are detailed in the [Contributor Roles](https://github.com/instructlab/community/blob/main/CONTRIBUTOR_ROLES.md). The list of current maintainers can be found [here](https://github.com/instructlab/community/blob/main/MAINTAINERS.md).
 
-## InstructLab Oversight Committee overview
+## InstructLab Oversight Committee Overview
 
-The Oversight Committee is selected by project Maintainers and consists of 3 to 9 leaders on the InstructLab project; these members will serve to supervise the overall project and its health. It will also consist of a selected chair member who will set agendas and call meetings; these meetings can be public or private at the discretion of the Oversight Committee.
+The initial Oversight Committee at the launch of the project was appointed by the founding sponsors of the InstructLab project. This bootstrap committee will serve until the first election of the Oversight Committee using processes and timing as determined by this group.
+
+The Oversight Committee consists of 3 to 7 leaders on the InstructLab project.  These members will serve to supervise the overall project and its health. It will also consist of a selected Chair member who will set agendas and call meetings. These meetings can be public or private at the discretion of the Oversight Committee.
 
 The Oversight Committee is responsible for the following duties:
 
 * Maintaining the mission, vision, values, and scope of the project
 * Refining the governance and charter as needed
-* Making project level decisions, including setting technical policies that apply across all components
+* Making project-level decisions, including setting technical policies that apply across all components
 * Resolving escalated project decisions when the team responsible is blocked
 * Managing the InstructLab brand
 * Controlling access to InstructLab assets such as source repositories and hosting
@@ -50,13 +48,11 @@ The Oversight Committee is responsible for the following duties:
 * Overseeing the resolution and disclosure of security issues
 * Managing financial decisions related to the project
 
-Until the Oversight Committee is selected, these duties will be carried out by the project Maintainers.
+### Draft Oversight Committee selection process
 
-### InstructLab Cross-Component Technical Policies
-
-Cross-component technical policies are out of scope for this project governance document, but can be found in the [InstructLab Enhancements Repo](https://github.com/instructlab/enhancements/blob/main/README.md).
-
-### Oversight Committee selection process
+> [!NOTE]
+> This section is a draft. It is a responsibility of the initial Oversight
+> Committee to finalize this process.
 
 The Oversight Committee will be selected and maintained using the following process:
 
@@ -66,11 +62,11 @@ The election will proceed according to the following process:
 
 1. The nomination period will be three weeks. This period starts from the day after an organization Maintainer opening becomes available.
 
-1. The nomination must be made on the InstructLab community Slack channel. Directions to join the Slack channel can be found [here](https://github.com/instructlab/community/blob/main/InstructLabSlackGuide.md). In the future, a mailing list will be established for nominations.
+1. The nomination must be made on the InstructLab [community mailing list](https://github.com/instructlab/community/blob/main/Collaboration.md#email-lists).
 
-1. After a nominated individual(s) agrees to be a candidate for the Oversight Committee, project Maintainers will vote. The voting period will be open for a minimum of three business days. It will remain open until a [supermajority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of project Maintainers has voted. Only current Maintainers of active projects are eligible to vote.
+1. After a nominated individual agrees to be a candidate for the Oversight Committee, project Maintainers will vote. The voting period will be open for a minimum of three business days. It will remain open until a [supermajority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of project Maintainers have voted. Only current Maintainers of active projects are eligible to vote.
 
-1. When the number of nominated individuals matches the number of openings, each individual must have a _Yes_ vote from a supermajority of those that voted.
+1. When the number of nominated individuals matches the number of openings, each individual must have a _Yes_ vote from a supermajority of those who voted.
 
 1. When there are more individuals than open positions, voting will use a _Ranked Choice_ voting method, such as [Condorcet](https://en.wikipedia.org/wiki/Condorcet_method).
 
@@ -78,7 +74,7 @@ The election will proceed according to the following process:
 
 Project Maintainers or Oversight Committee members may resign or could be expelled as follows:
 
-* Maintainers or an Oversight Committee member may step down through email. Within 7 calendar days, organization contributors and Maintainers will be notified on the InstructLab community Slack channel. Directions to join the Slack channel can be found [here](https://github.com/instructlab/community/blob/main/InstructLabSlackGuide.md). In the future, a mailing list will be established.
+* Maintainers or an Oversight Committee member may step down through email. Within 7 calendar days, organization contributors and Maintainers will be notified on the InstructLab [community mailing list](https://github.com/instructlab/community/blob/main/Collaboration.md#email-lists).
 
 * After an Oversight Committee member steps down, they become an emeritus Maintainer.
 
@@ -90,32 +86,32 @@ Project Maintainers or Oversight Committee members may resign or could be expell
 
 Generally, there are methods for decision making for the InstructLab project: by lazy consensus or by voting.
 
-The default decision making process is [_lazy-consensus_](http://communitymgt.wikia.com/wiki/Lazy_consensus). This means that any decision is considered supported by the team making it so long as no one objects. Silence on any consensus decision is implicit agreement, and equivalent to explicit agreement. Explicit agreement may be stated at will.
+The default decision-making process is [_lazy-consensus_](http://communitymgt.wikia.com/wiki/Lazy_consensus). This means that any decision is considered supported by the team making it so long as no one objects. Silence on any consensus decision is implicit agreement, and equivalent to explicit agreement. An explicit agreement may be stated at will.
 
 When a consensus cannot be met, a Maintainer can call for a [majority](https://en.wikipedia.org/wiki/Majority) vote on a decision.
 
-Many of the day-to-day project maintenance can be done by through the lazy consensus model.
+Many of the day-to-day project maintenance can be done through the lazy consensus model.
 
-The secondary decision making process is done by voting. The following items must be called to a vote and conducted by the appropriate body:
+The secondary decision-making process is done by voting. The following items are examples that must be called to a vote and conducted by the appropriate body:
 
-* Appointing or removing a member of the [Code of Conduct Committee](https://github.com/instructlab/community/blob/main/COCC.md) (supermajority)
-* Carrying out [Code of Conduct](https://github.com/instructlab/community/blob/main/CODE_OF_CONDUCT.md) decisions requiring severe censure (majority)
-* Removing a [Maintainer](https://github.com/instructlab/community/blob/main/MAINTAINERS.md) for any reason other than inactivity (supermajority)
-* Changing the governance (that is, this document's) rules (supermajority)
-* Licensing and intellectual property changes such as new logos or wordmarks (simple majority)
-* Adding, archiving, or removing projects (simple majority)
+* Appointing or removing a member of the [Code of Conduct Committee](https://github.com/instructlab/community/blob/main/COCC.md) (supermajority of the Oversight Committee)
+* Carrying out [Code of Conduct](https://github.com/instructlab/community/blob/main/CODE_OF_CONDUCT.md) decisions requiring severe censure (majority of the Code of Conduct committee)
+* Removing a [Maintainer](https://github.com/instructlab/community/blob/main/MAINTAINERS.md) for any reason other than inactivity (supermajority of the Oversight Committee)
+* Non-trivial changes to the governance (this document) (supermajority of the Oversight Committee)
+* Licensing and intellectual property changes such as new logos or wordmarks (majority of the Oversight Committee)
+* Adding, archiving, or removing projects (majority of the Oversight Committee)
 
-Other decisions may, but do not need to be, called out and put up for decision  on the InstructLab community Slack channel. Directions to join the Slack channel can be found [here](https://github.com/instructlab/community/blob/main/InstructLabSlackGuide.md). In the future, a mailing list will be established. This can be done by anyone at any time. By default, any decisions called to a vote will be for a _simple majority_ vote.
+Other decisions may be called out and put up for decision on the InstructLab [community mailing list](https://github.com/instructlab/community/blob/main/Collaboration.md#email-lists). This can be done by anyone at any time. By default, any decisions called to a vote will be for a _simple majority_ vote of the Oversight Committee.
 
 ## Code of Conduct
 
-InstructLab's [Code of Conduct](https://github.com/instructlab/community/blob/main/CODE_OF_CONDUCT.md) is enforced by the [Code of Conduct Committee (CoCC)](https://github.com/instructlab/community/blob/main/COCC.md). This committee will be appointed and removed by the Oversight Committee, or by the project Maintainers before the Oversight Committee is created, using a supermajority vote.  
+InstructLab's [Code of Conduct](https://github.com/instructlab/community/blob/main/CODE_OF_CONDUCT.md) is enforced by the [Code of Conduct Committee (CoCC)](https://github.com/instructlab/community/blob/main/COCC.md). This committee will be appointed and removed by the Oversight Committee using a supermajority vote.
 
 The CoCC is responsible for investigating, evaluating, and recommending remedies for substantiated Code of Conduct incidents to the appropriate body. The CoCC will judge possible violations around principles of restorative justice rather than punishment. All teams within InstructLab are obligated to support the CoCC's recommendations on remedies.
 
 Current CoCC members can be found on the [Code of Conduct Committee](https://github.com/instructlab/community/blob/main/COCC.md) page.
 
-Possible Code of Conduct violations should be reported to the Code of Conduct Committee on the InstructLab community Slack channel. Directions to join the Slack channel can be found [here](https://github.com/instructlab/community/blob/main/InstructLabSlackGuide.md). In the future, a mailing list will be established.
+Possible Code of Conduct violations should be reported to the Code of Conduct Committee via the [Code of Conduct email alias](https://github.com/instructlab/community/blob/main/Collaboration.md#email-lists).
 
 ## Developer Certificate of Origin (DCO) and Licenses
 
@@ -127,4 +123,6 @@ The following licenses and contributor agreements will be used for InstructLab p
 
 ## Modifications to this Governance
 
-This governance may be modified by a supermajority of the Oversight Committee, or by a supermajority of all project Maintainers.
+This governance may be modified by a supermajority vote of the Oversight Committee.
+
+Trivial changes that do not introduce policy changes may be approved by two members of the Oversight Committee.

--- a/tools/maintainers/maintainers.py
+++ b/tools/maintainers/maintainers.py
@@ -43,7 +43,9 @@ def main(argv=None):
                 members = get_team_members(t["slug"])
                 members_sorted = sorted(members, key=lambda d: d["login"].lower())
                 for m in members_sorted:
-                    print("- [%s](https://github.com/%s)" % (m["login"], m["login"]))
+                    print("- [%s](https://github.com/%s)%s" % (
+                        m["login"], m["login"],
+                        " - Chair" if "chair" in t and m["login"] == t["chair"] else ""))
 
     return 0
 

--- a/tools/maintainers/teams.yaml
+++ b/tools/maintainers/teams.yaml
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
+InstructLab:
+- name: Oversight Committee
+  desc: The project-wide oversight committee
+  slug: oversight-committee
+  chair: russellb
+
 CLI:
 - name: CLI Maintainers
   desc: Team which has full maintainer access to the CLI repository


### PR DESCRIPTION
The governance doc discussed an oversight committee, but one had not
yet been created. This change reflects an initial bootstrapping
oversight committee appointed at the launch of the project that will
serve in this function as the project gets started. One of the roles
of this group will be to finalize the governance processes for this
committee for the future.

While in the doc anyway, I did some other minor cleanups - minor
grammatical issues and references to things that don't exist.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
