### PR TITLE
README.md: Fix two spelling errors

### DIFF
--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -8,7 +8,7 @@ matrix:
     camel-case: true
     mode: markdown
   sources:
-  - "**/*.md|!.tox/**"
+  - "**/*.md|!.tox/**|!venv/**"
   dictionary:
     wordlists:
     - .spellcheck-en-custom.txt

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ md-lint: ## Lint markdown files
 	$(ECHO_PREFIX) printf "  %-12s ./...\n" "[MD LINT]"
 	$(CMD_PREFIX) podman run --rm -v $(CURDIR):/workdir --security-opt label=disable docker.io/davidanson/markdownlint-cli2:latest > /dev/null
 
+.PHONY: spellcheck
+spellcheck:
+	$(CMD_PREFIX) python -m pyspelling --config .spellcheck.yml --spellchecker aspell
+
 .PHONY: spellcheck-sort
 spellcheck-sort: .spellcheck-en-custom.txt
 	sort -d -f -o $< $<

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The mission of the InstructLab (**L**arge-scale **A**lignment for chat**B**ots) 
 
 InstructLab is made up of several projects that are defined as codebases and services with different release cycles. Collectively, these enable large-model development. This repository shares InstructLab's activity and collaboration details across the community and include the most current information about the project. Related repositories include the following:
 
-* [taxonomy tree](https://github.com/instructlab/taxonomy) of knowlege and skils.
+* [taxonomy tree](https://github.com/instructlab/taxonomy) of knowledge and skills.
 * [`ilab` command-line interface (CLI) tool](https://github.com/instructlab/instructlab). This repository is responsible for the `ilab` command-line interface (CLI) tool.
 
 Contributing new features, resolving bugs and issues, and refining the documentation experience through pull requests are welcome. More information about contributing to the InstructLab Project, contributor roles, governance and legal, and licenses can be found in proceeding sections of this document.


### PR DESCRIPTION
Also add a `spellcheck` target to the Makefile to make it easier to
run.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
