### PR TITLE
maintainers: Place github id in code block to sidestep spellcheck

### DIFF
--- a/tools/maintainers/maintainers.py
+++ b/tools/maintainers/maintainers.py
@@ -43,7 +43,7 @@ def main(argv=None):
                 members = get_team_members(t["slug"])
                 members_sorted = sorted(members, key=lambda d: d["login"].lower())
                 for m in members_sorted:
-                    print("- [%s](https://github.com/%s)%s" % (
+                    print("- [`%s`](https://github.com/%s)%s" % (
                         m["login"], m["login"],
                         " - Chair" if "chair" in t and m["login"] == t["chair"] else ""))
 


### PR DESCRIPTION
Currently the github ids are spellchecked which then causes problems when a new github id is added to a team.