### PR TITLE
fix: add spellcheck and spellcheck-sort to 'make help'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ md-lint: ## Lint markdown files
 	$(CMD_PREFIX) podman run --rm -v $(CURDIR):/workdir --security-opt label=disable docker.io/davidanson/markdownlint-cli2:latest > /dev/null
 
 .PHONY: spellcheck
-spellcheck:
+spellcheck: ## Spellcheck markdown files
 	$(CMD_PREFIX) python -m pyspelling --config .spellcheck.yml --spellchecker aspell
 
 .PHONY: spellcheck-sort
-spellcheck-sort: .spellcheck-en-custom.txt
+spellcheck-sort: .spellcheck-en-custom.txt ## Sort spellcheck directory
 	sort -d -f -o $< $<


### PR DESCRIPTION
Example of before/after below
```bash
[nathan@nathan-redhat community (md-help)]$ make help

Usage:
  make <target>
  md-lint             Lint markdown files
[nathan@nathan-redhat community (md-help)]$ make help

Usage:
  make <target>
  md-lint             Lint markdown files
  spellcheck          Spellcheck markdown files
  spellcheck-sort     Sort spellcheck directo