### PR TITLE
Update dependabot.yml for /tools/triage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,7 @@ updates:
     directory: "/tools/maintainers"
     schedule:
       interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tools/triage"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
We need to keep python deps for /tools/triage up to date. 

This will address a CVE in one of the deps by updating to use a fixed version.