### PR TITLE
maintainers: Add SDG maintainers team

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -122,6 +122,7 @@ Mahbobi
 Maintainership
 maintainership
 mairin
+Máirín
 Maredia
 markstur
 Marymount
@@ -139,7 +140,6 @@ mrutkows
 mscherer
 Multivariable
 Musique
-Máirín
 nathan
 nerdalert
 Neth
@@ -185,6 +185,7 @@ Sandhills
 Sanny
 Schlicker
 Schneegurt
+SDG
 Seminario
 Sepi
 SETI

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -75,15 +75,6 @@ Team which has full maintainer access to the Community repository
 - [`mingxzhao`](https://github.com/mingxzhao)
 - [`mmcelaney`](https://github.com/mmcelaney)
 
-## Enhancements
-
-### Enhancements Triagers
-
-Team which has full maintainer access to the Enhancements repository
-
-- [`nathan-weinberg`](https://github.com/nathan-weinberg)
-- [`russellb`](https://github.com/russellb)
-
 ## InstructLabBot
 
 ### InstructLab Bot Maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -105,6 +105,26 @@ Team which has full maintainer access to the Schema repository
 - [`bjhargrave`](https://github.com/bjhargrave)
 - [`jjasghar`](https://github.com/jjasghar)
 
+## SDG
+
+### SDG Maintainers
+
+Team which has full maintainer access to the SDG repository
+
+- [`aakankshaduggal`](https://github.com/aakankshaduggal)
+- [`abhi1092`](https://github.com/abhi1092)
+- [`alimaredia`](https://github.com/alimaredia)
+- [`alinaryan`](https://github.com/alinaryan)
+- [`cdoern`](https://github.com/cdoern)
+- [`jaideepr97`](https://github.com/jaideepr97)
+- [`JamesKunstle`](https://github.com/JamesKunstle)
+- [`khaledsulayman`](https://github.com/khaledsulayman)
+- [`nathan-weinberg`](https://github.com/nathan-weinberg)
+- [`oindrillac`](https://github.com/oindrillac)
+- [`RobotSail`](https://github.com/RobotSail)
+- [`russellb`](https://github.com/russellb)
+- [`xukai92`](https://github.com/xukai92)
+
 ## Taxonomy
 
 ### Taxonomy Approvers

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,8 @@ spellcheck: ## Spellcheck markdown files
 .PHONY: spellcheck-sort
 spellcheck-sort: .spellcheck-en-custom.txt ## Sort spellcheck directory
 	sort -d -f -o $< $<
+
+.PHONY: maintainers
+maintainers: tools/maintainers/teams.yaml ## Update MAINTAINERS.md
+	$(ECHO_PREFIX) printf "  %-12s $<\n" "[MAINTAINERS.md]"
+	$(CMD_PREFIX) python tools/maintainers/maintainers.py $< > MAINTAINERS.md

--- a/tools/maintainers/teams.yaml
+++ b/tools/maintainers/teams.yaml
@@ -32,6 +32,11 @@ Schema:
   desc: Team which has full maintainer access to the Schema repository
   slug: schema-maintainers
 
+SDG:
+- name: SDG Maintainers
+  desc: Team which has full maintainer access to the SDG repository
+  slug: sdg-maintainers
+
 Taxonomy:
 - name: Taxonomy Approvers
   desc: Team which has approval permissions to the Taxonomy repository

--- a/tools/maintainers/teams.yaml
+++ b/tools/maintainers/teams.yaml
@@ -19,11 +19,6 @@ Community:
   desc: Team which has full maintainer access to the Community repository
   slug: community-maintainers
 
-Enhancements:
-- name: Enhancements Triagers
-  desc: Team which has full maintainer access to the Enhancements repository
-  slug: enhancements-triagers
-
 InstructLabBot:
 - name: InstructLab Bot Maintainers
   desc: Team which has full maintainer access to the InstructLab Bot repository


### PR DESCRIPTION

1b4370e Makefile: Add maintainers target
d7fc982 maintainers: Drop enhancements triagers
01c75c4 maintainers: Add sdg maintainers team

commit 1b4370e1fc81aff173e21a9e742ea972b0c2020d
Author: Russell Bryant <rbryant@redhat.com>
Date:   Sat Jun 1 11:48:02 2024 -0400

    Makefile: Add maintainers target
    
    Add a target as a shortcut for updating `MAINTAINERS.md`.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit d7fc982ed53a6fd01da5d517057884160d762aa4
Author: Russell Bryant <rbryant@redhat.com>
Date:   Sat Jun 1 11:45:29 2024 -0400

    maintainers: Drop enhancements triagers
    
    This team wasn't really used. All maintainers teams have access to
    this repo, which includes the two people included in this triager
    team.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 01c75c4c52ad9d04b77c6027a140d846621190ea
Author: Russell Bryant <rbryant@redhat.com>
Date:   Sat Jun 1 11:49:20 2024 -0400

    maintainers: Add sdg maintainers team
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
