### PR TITLE
maintainers: Add teams for training and eval repos

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -68,6 +68,8 @@ Duggal
 Eder
 Eggebrecht
 et
+Eval
+eval
 Fraknoi
 Freeform
 freeform
@@ -127,6 +129,7 @@ Mahbobi
 Maintainership
 maintainership
 mairin
+Máirín
 Maredia
 markstur
 Marymount
@@ -147,7 +150,6 @@ mrutkows
 mscherer
 Multivariable
 Musique
-Máirín
 nathan
 nerdalert
 Neth

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -75,6 +75,27 @@ Team which has full maintainer access to the Community repository
 - [`mingxzhao`](https://github.com/mingxzhao)
 - [`mmcelaney`](https://github.com/mmcelaney)
 
+## Eval
+
+### Eval Maintainers
+
+Team which has full maintainer access to the eval repository
+
+- [`aakankshaduggal`](https://github.com/aakankshaduggal)
+- [`abhi1092`](https://github.com/abhi1092)
+- [`alimaredia`](https://github.com/alimaredia)
+- [`alinaryan`](https://github.com/alinaryan)
+- [`cdoern`](https://github.com/cdoern)
+- [`jaideepr97`](https://github.com/jaideepr97)
+- [`JamesKunstle`](https://github.com/JamesKunstle)
+- [`khaledsulayman`](https://github.com/khaledsulayman)
+- [`Maxusmusti`](https://github.com/Maxusmusti)
+- [`nathan-weinberg`](https://github.com/nathan-weinberg)
+- [`oindrillac`](https://github.com/oindrillac)
+- [`RobotSail`](https://github.com/RobotSail)
+- [`russellb`](https://github.com/russellb)
+- [`xukai92`](https://github.com/xukai92)
+
 ## InstructLabBot
 
 ### InstructLab Bot Maintainers
@@ -163,6 +184,27 @@ Team that can manage Issues and Pull Requests but cannot merge code to the Taxon
 - [`ljmwaugh`](https://github.com/ljmwaugh)
 - [`mingxzhao`](https://github.com/mingxzhao)
 - [`oindrillac`](https://github.com/oindrillac)
+- [`xukai92`](https://github.com/xukai92)
+
+## Training
+
+### Training Maintainers
+
+Team which has full maintainer access to the training repository
+
+- [`aakankshaduggal`](https://github.com/aakankshaduggal)
+- [`abhi1092`](https://github.com/abhi1092)
+- [`alimaredia`](https://github.com/alimaredia)
+- [`alinaryan`](https://github.com/alinaryan)
+- [`cdoern`](https://github.com/cdoern)
+- [`jaideepr97`](https://github.com/jaideepr97)
+- [`JamesKunstle`](https://github.com/JamesKunstle)
+- [`khaledsulayman`](https://github.com/khaledsulayman)
+- [`Maxusmusti`](https://github.com/Maxusmusti)
+- [`nathan-weinberg`](https://github.com/nathan-weinberg)
+- [`oindrillac`](https://github.com/oindrillac)
+- [`RobotSail`](https://github.com/RobotSail)
+- [`russellb`](https://github.com/russellb)
 - [`xukai92`](https://github.com/xukai92)
 
 ## Website

--- a/tools/maintainers/teams.yaml
+++ b/tools/maintainers/teams.yaml
@@ -19,6 +19,11 @@ Community:
   desc: Team which has full maintainer access to the Community repository
   slug: community-maintainers
 
+Eval:
+- name: Eval Maintainers
+  desc: Team which has full maintainer access to the eval repository
+  slug: eval-maintainers
+
 InstructLabBot:
 - name: InstructLab Bot Maintainers
   desc: Team which has full maintainer access to the InstructLab Bot repository
@@ -47,6 +52,11 @@ Taxonomy:
 - name: Taxonomy Triagers
   desc: Team that can manage Issues and Pull Requests but cannot merge code to the Taxonomy repository
   slug: taxonomy-triagers
+
+Training:
+- name: Training Maintainers
+  desc: Team which has full maintainer access to the training repository
+  slug: training-maintainers
 
 Website:
 - name: Website Maintainers


### PR DESCRIPTION
Add the teams associated with the training and eval library repos.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
