### PR TITLE
docs: add section regarding contributor role communcation

### DIFF
--- a/CONTRIBUTOR_ROLES.md
+++ b/CONTRIBUTOR_ROLES.md
@@ -144,6 +144,11 @@ If an emeritus Maintainer or other retired contributor wants to regain an active
 
 Changes to contributor roles must be approved by a vote of the Oversight Committee or a majority of the current project's Maintainers.
 
+## Communication of contributor role changes
+
+Changes to contributor roles must be communicated by a member of the Oversight Committee to the community. This should be done via both
+Slack and Email to an appropriate channel/list respectively. The communication should happen as soon as the role change is made on GitHub.
+
 ## Acknowledgements
 
 Contributor roles and responsibilities were written based on various CNCF projects membership and the [Contributor Ladder Template](https://github.com/cncf/project-template/blob/main/CONTRIBUTOR_LADDER.md).


### PR DESCRIPTION
In https://github.com/instructlab/community/pull/326 we gave the Oversight Committee ultimate authority over Contributor Roles. However, this has led to folks being added/removed with no communication to the community. I myself only noticed when looking here: https://github.com/instructlab/community/commits/main/MAINTAINERS.md

This communication is not something that is currently required, but I feel that it should be. This PR adds a section for the Contributor Roles governance that requires communication around role changes going forward.