### PR TITLE
Require Maintainers to be Triagers

### DIFF
--- a/CONTRIBUTOR_ROLES.md
+++ b/CONTRIBUTOR_ROLES.md
@@ -115,9 +115,13 @@ Maintainers will vote publicly on the issue, expressing their support via a GitH
 
 After a [decision has been made](https://github.com/instructlab/community/blob/main/governance.md#decision-making-at-the-instructlab-org-level), a Maintainer will create a PR to add you in the [MAINTAINER file](https://github.com/instructlab/community/blob/main/MAINTAINERS.md) within three weeks.
 
+All Maintainers are Triagers. If a candidate is not a Triager at the time of the nomination, they should be added to both Triagers and Maintainers teams.
+
 #### Maintainer responsibilities and Privileges
 
-As a project Maintainer, you have the following responsibilities and privileges:
+All Maintainers are Triagers and share all of the appropriate [responsibilities and privileges](#triager-responsibilities-and-privileges).
+
+In addition, as a project Maintainer, you have the following responsibilities and privileges:
 
 * You make and approve technical design decisions.
 * You set technical direction and priorities.


### PR DESCRIPTION
The project is looking for ways to improve community relationships, and one of the suggestions is to require maintainers to share triager responsibilities to provide timely and useful feedback to contributors on their issues and pull requests.

The proposal is to assume privileges and responsibilities and membership is monotonically expanding so that:

- all triagers are members (already the case);
- all maintainers are triagers (this proposal).

Or if these were python sets, then... ;)

```
Contributor <= Member <= Triager <= Maintainer
```

Context: we are considering automatic assignment of a number of Triagers to every new pull request, and it's important that this burden is shared by all seasoned members, incl. maintainers.

Note: once this is approved, someone should walk through the list of current Maintainers and add them to Triagers groups for appropriate repos. Alternatively, Maintainers groups can be converted into nested groups, see:

https://docs.github.com/en/organizations/organizing-members-into-teams/about-teams#nested-teams