### PR TITLE
ci: add exempt label for community issues

### DIFF
--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -33,15 +33,16 @@ jobs:
         with:
           stale-issue-label: 'stale'
           stale-issue-message: >
-            This issue has been automatically marked as stale because it has not had activity within 90 days.
+            This issue has been automatically marked as stale because it has not had activity within 60 days.
             It will be automatically closed if no further activity occurs within 30 days.
           close-issue-message: >
             This issue has been automatically closed due to inactivity. Please feel free to reopen if you feel it is still relevant!
           days-before-issue-stale: 60
           days-before-issue-close: 30
+          exempt-issue-labels: 'ongoing'
           stale-pr-label: 'stale'
           stale-pr-message: >
-            This pull request has been automatically marked as stale because it has not had activity within 90 days.
+            This pull request has been automatically marked as stale because it has not had activity within 60 days.
             It will be automatically closed if no further activity occurs within 30 days.
           close-pr-message: >
             This pull request has been automatically closed due to inactivity. Please feel free to reopen if you intend to continue working on it!


### PR DESCRIPTION
allows for custom label "ongoing" to stop Stale Bot from labeling issues with that label as "stale"