### PR TITLE
docs: add one-click calendar link

### DIFF
--- a/Collaboration.md
+++ b/Collaboration.md
@@ -10,11 +10,10 @@ If you need help getting started with using or contributing to InstructLab, the 
 
 ## [Project Meetings](#project-meetings)
 
-To stay up to date on when meetings are added and how to join them, subscribe to the
-[InstructLab project calendar](https://calendar.google.com/calendar/embed?src=c_23c2f092cd6d147c45a9d2b79f815232d6c3e550b56c3b49da24c4b5d2090e8f%40group.calendar.google.com)
-by clicking the button in the bottom right of the calendar view or simply add the
-[InstructLab calendar ics feed URL](https://calendar.google.com/calendar/ical/c_23c2f092cd6d147c45a9d2b79f815232d6c3e550b56c3b49da24c4b5d2090e8f%40group.calendar.google.com/public/basic.ics)
-to your preferred mail app.
+To stay up to date on new meetings and how to join them, [click here](https://calendar.google.com/calendar/u/0/r?cid=c_23c2f092cd6d147c45a9d2b79f815232d6c3e550b56c3b49da24c4b5d2090e8f@group.calendar.google.com)
+to subscribe to the [InstructLab project calendar](https://calendar.google.com/calendar/embed?src=c_23c2f092cd6d147c45a9d2b79f815232d6c3e550b56c3b49da24c4b5d2090e8f%40group.calendar.google.com)
+or add the [ICS/iCal feed URL](https://calendar.google.com/calendar/ical/c_23c2f092cd6d147c45a9d2b79f815232d6c3e550b56c3b49da24c4b5d2090e8f%40group.calendar.google.com/public/basic.ics)
+to your preferred calendar app.
 
 The project will host more meetings as it evolves, but those we have already set up are listed here.
 


### PR DESCRIPTION
Adds a direct link to subscribe to the community calendar, removing the need to describe where to find the tiny "Add" button in the embedded version. Re-words the paragraph slightly to incorporate it and make it the first link.

Also adds a mention of "iCal" which may be a more familiar keyword to some visitors.