### PR TITLE
update references throughout the repo to include Discord

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -244,6 +244,7 @@ weinberg
 Wikimedia
 wikimultihop
 wordmarks
+workspaces
 workstreams
 WSL
 xukai

--- a/CODE_OF_CONDUCT_COMMITTEE.md
+++ b/CODE_OF_CONDUCT_COMMITTEE.md
@@ -8,9 +8,11 @@ To report a Code of Conduct violation to our Code of Conduct Committee, you may 
 [coc@instructlab.ai](mailto:coc@instructlab.ai). The email will be read and acted upon by our Code of Conduct Committee
 members.
 
-If you experience a Code of Conduct violation in our InstructLab Slack workspace, please follow the
-[instructions in our moderation guide](https://github.com/instructlab/community/blob/main/InstructLab_SLACK_MODERATION_GUIDE.md#reporting-abuse)
-to get immediate help in Slack.
+If you experience a Code of Conduct violation in our InstructLab Discord or Slack workspace, please follow the
+instructions in our moderation guides:
+
+- [Slack moderation guide](https://github.com/instructlab/community/blob/main/InstructLab_SLACK_MODERATION_GUIDE.md#reporting-abuse)
+- [Discord moderation guide](https://github.com/instructlab/community/blob/main/InstructLab_DISCORD_MODERATION_GUIDE.md#reporting-abuse)
 
 As part of our follow up on your report, we would like to contact you for further discussion. If you would prefer not to
 engage beyond reporting the matter to the committee, please let us know that as part of your submission. We will respect

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,6 +172,7 @@ There are a number of tools that make it easier for developers to manage DCO sig
 ## Communication
 
 You can join the
+[InstructLab Discord server](https://instructlab.ai/discord) or
 [InstructLab Slack workspace](https://github.com/instructlab/community/blob/main/InstructLabSlackGuide.md) to
 communicate with project maintainers and your fellow users.
 

--- a/CONTRIBUTOR_ROLES.md
+++ b/CONTRIBUTOR_ROLES.md
@@ -61,7 +61,7 @@ To become a project Member, you must meet the following requirements:
 
   - Authoring or reviewing PRs on GitHub.
   - Filing or commenting on issues on GitHub.
-  - Contributing to community discussion, for example, meetings or on Slack.
+  - Contributing to community discussion, for example, meetings or on Discord/Slack.
 
 - You have been sponsored by two Maintainers.
 
@@ -96,7 +96,7 @@ To become a project Triager, you must meet the following requirements:
 
   - Triaging open issues or PRs.
   - Authoring or reviewing PRs on GitHub.
-  - Contributing to community discussions (e.g. meetings, Slack).
+  - Contributing to community discussions (e.g. meetings, Discord/Slack).
 
 - You have been sponsored by two Maintainers.
 
@@ -133,7 +133,7 @@ To become a project Maintainer, you must meet the following requirements:
 - You have a deep understanding of the technical domain of the project.
 - You have made sustained contributions to design and direction by:
   - Authoring and reviewing proposals.
-  - Initiating, contributing, and resolving discussions, such as emails, Slack, GitHub issues, meetings.
+  - Initiating, contributing, and resolving discussions, such as emails, Discord, Slack, GitHub issues, meetings.
   - Identifying subtle or complex issues in designs and implementation pull requests.
 - You have directly contributed to the project through implementation and/or review.
 - You have been sponsored by two Maintainers.
@@ -195,8 +195,8 @@ project's Maintainers.
 ## Communication of contributor role changes
 
 Changes to contributor roles must be communicated by a member of the Oversight Committee to the community. This should
-be done via both Slack and Email to an appropriate channel/list respectively. The communication should happen as soon as
-the role change is made on GitHub.
+be done via Discord, Slack and Email to an appropriate channel/list respectively. The communication should happen as
+soon as the role change is made on GitHub.
 
 ## Acknowledgements
 

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -6,7 +6,8 @@ fellow users, or subscribe for project updates.
 ## Getting Started with InstructLab
 
 If you need help getting started with using or contributing to InstructLab, the best way to do so is via our
-[project Slack workspace](#chat) or [email lists](#email-lists) rather than posts on social media.
+project [Discord](#discord-chat) or [Slack](#slack-chat) workspaces, or [email lists](#email-lists) rather than posts
+on social media.
 
 ## [Project Meetings](#project-meetings)
 
@@ -63,7 +64,14 @@ to review development underway to [create and iterate upon a GUI](https://github
 If you are interested in user interface design, user experience, and simplifying the contribution experience, you are
 welcome and encouraged to join.
 
-## [Chat](#chat)
+## [Discord Chat](#discord-chat)
+
+To participate in discussions about the project and chat with other community members, please join our
+[InstructLab Discord Server](https://instructlab.ai/discord).
+To learn more about our Discord server, see:
+[InstructLab Discord Guide](https://github.com/instructlab/community/blob/main/InstructLab_DISCORD_GUIDE.md)
+
+## [Slack Chat](#slack-chat)
 
 For real-time chat discussions, please join our
 [InstructLab Slack workspace](https://github.com/instructlab/community/blob/main/InstructLab_SLACK_GUIDE.md).
@@ -71,11 +79,11 @@ For real-time chat discussions, please join our
 Slack history is deleted after 90 days, so for conversations that should preserved for a longer period use the
 [project mailing lists](#email-lists).
 
+## [Email Lists](#email-lists)
+
 If you want to add feedback or think there is a "large issue" to discuss, a mailing list or a specific repository issue
 tracker is a good place to have the conversation rather than Slack. If you are unsure of where to comment,
 [users@instructlab.ai](https://groups.google.com/a/instructlab.ai/g/users) is the best place to start.
-
-## [Email Lists](#email-lists)
 
 We use the following email lists for project communications. Subscriptions requires a
 [Google account](https://www.google.com/account/about/).
@@ -118,7 +126,7 @@ We are using the GitHub discussion boards in each repo for cases where we need t
 ephemerally, such as working together as a community to squash a nasty bug. In that case, a link to the appropriate
 discussion board post will be sent to the relevant project mailing lists so folks can follow along on GitHub. Rather
 than use the discussion boards to discuss proposals for enhancements or to request help with using InstructLab, please
-reach out on the project [email lists](#email-lists) or [Slack](#chat).
+reach out on the project [email lists](#email-lists) or  on [Discord](#discord-chat) or [Slack](#slack-chat).
 
 ## [Hugging Face](#hugging-face)
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -116,7 +116,8 @@ are integrated while enriching the model’s capabilities over time.
 
 You can begin your contribution journey by reading over the
 [Contributing](https://github.com/instruct-lab/community/blob/main/CONTRIBUTING.md) guide and joining the
-[Community Slack Channel](https://github.com/instructlab/community/blob/main/InstructLabSlackGuide.md).
+[Community Discord Server](https://github.com/instructlab/community/blob/main/InstructLab_DISCORD_GUIDE.md) or
+[Community Slack Channel](https://github.com/instructlab/community/blob/main/InstructLab_SLACK_GUIDE.md).
 
 When you're ready to start contributing, you can follow the
 [Getting Started](https://github.com/instruct-lab/community/blob/main/README.md#getting-started-with-the-instructlab-project-workstreams)
@@ -326,8 +327,10 @@ The latest version of InstructLab can be downloaded using the `ilab download` CL
 
 ### I have a question about the project. Where should I go?
 
-Currently, the best method for communicating with peers and project maintainers is in the Community Slack Channel. Visit
-our [InstructLab Slack Workspace Guide](https://github.com/instructlab/community/blob/main/InstructLabSlackGuide.md) for
+Currently, the best method for communicating with peers and project maintainers is in the Community Discord Server or
+Slack Channel. Visit our
+InstructLab [Discord Server Guide](https://github.com/instructlab/community/blob/main/InstructLab_DISCORD_GUIDE.md)
+or [Slack Workspace Guide](https://github.com/instructlab/community/blob/main/InstructLabSlackGuide.md) for
 information on how to join.
 
 TODO: Update with mailing list details once these are created. Related issue
@@ -382,7 +385,7 @@ To run and train InstructLab locally, you must meet the following requirements:
 ## Additional Resources
 
 Additional resources, including the Code of Conduct, Code of Conduct Committee members, how to contribute, how to join
-the Slack channel, and more, can be found in the following repositories:
+the Discord server, Slack channel, and more, can be found in the following repositories:
 
 [InstructLab Taxonomy Repository](https://github.com/instructlab/taxonomy)
 
@@ -390,7 +393,9 @@ the Slack channel, and more, can be found in the following repositories:
 
 [InstructLab Community Repository](https://github.com/instructlab/community)
 
-Slack and communication
+Discord, Slack and communication
 
+- [Joining the Discord Server](https://github.com/instructlab/community/blob/main/InstructLab_DISCORD_GUIDE.md)
+- [Discord Moderation](https://github.com/instructlab/community/blob/main/InstructLab_DISCORD_MODERATION_GUIDE.md)
 - [Joining the Slack Channel](https://github.com/instructlab/community/blob/main/InstructLabSlackGuide.md)
 - [Slack Moderation](https://github.com/instructlab/community/blob/main/InstructLabSlackModerationGuide.md)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -22,10 +22,14 @@ decisions that affect only one project, such as the taxonomy repository and not 
 the taxonomy project. While communication between the different project teams is important as they are all
 interconnected, minor decisions do not need organization-wide consensus and can be moved forward at the project level.
 
-Changes in maintainership and other governance are currently announced on the InstructLab community Slack channel.
-Directions to join the Slack channel can be found
-[here](https://github.com/instructlab/community/blob/main/InstructLabSlackGuide.md). Changes are also announced to the
+Changes in maintainership and other governance are currently announced on the InstructLab community Discord server and
+Slack channel. Changes are also announced to the
 [announce mailing list](https://github.com/instructlab/community/blob/main/Collaboration.md#email-lists).
+
+For more information on how to join these channels, please see the following guides:
+
+- [InstructLab Discord Server](https://github.com/instructlab/community/blob/main/InstructLab_DISCORD_GUIDE.md)
+- [InstructLab Slack Server](https://github.com/instructlab/community/blob/main/InstructLab_SLACK_GUIDE.md)
 
 ## Project Maintainers overview
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ and train the model locally.
 
 > **Note:** Before proceeding, it might be beneficial to check out the
 > [Contributing](https://github.com/instruct-lab/community/blob/main/CONTRIBUTING.md) guide for an overview of
-> contributing practices and expectations. Additionally, you should consider joining the
-> [InstructLab community Slack channel](InstructLab_SLACK_GUIDE.md).
+> contributing practices and expectations. Additionally, you should consider joining the InstructLab Discord & Slack
+> spaces:
+>
+> - [InstructLab community Discord server](InstructLab_DISCORD_GUIDE.md)
+> - [InstructLab community Slack channel](InstructLab_SLACK_GUIDE.md).
 
 1. Navigate to the `ilab` CLI repository and follow the instructions in the
    [README.md](https://github.com/instructlab/instructlab/blob/main/README.md). The README.md instructs you on how to
@@ -179,6 +182,10 @@ If you would like to see the detailed LICENSE click, see [LICENSE](LICENSE).
 
 ## Contact resources
 
+- [InstructLab Discord](https://instructlab.ai/discord). See the InstructLab Discord Guide for more information on
+the server.
+- [InstructLab Discord Guide](InstructLab_DISCORD_GUIDE.md)
+- [InstructLab Discord Moderation Guide](InstructLab_DISCORD_MODERATION_GUIDE.md)
 - [InstructLab Slack](https://instruct-lab.slack.com). See the InstructLab Slack Guide for directions on how to join.
 - [InstructLab Slack Guide](InstructLab_SLACK_GUIDE.md)
 - [InstructLab Slack Moderation Guide](InstructLab_SLACK_MODERATION_GUIDE.md)


### PR DESCRIPTION
This PR updates references throughout the community repo to include Discord as one of our chat clients.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
