### PR TITLE
Update governance to acknowledge dev-docs repo governance process

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -28,6 +28,7 @@ Ashgar
 backend
 benchmarking
 Bernardino
+Bluesky
 bjhargrave
 Boelkins
 Byars
@@ -184,6 +185,7 @@ README
 Rebecca
 Redbooks
 redbooks
+Reddit
 Repo
 repo
 resynthesizes
@@ -217,6 +219,7 @@ Spielman
 spzala
 Stanberry
 Standup
+subreddit
 Sudalairaj
 supermajority
 Tatlock

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -152,17 +152,17 @@ Follow us on [X](https://twitter.com/instructlab) for our latest Tweets. Er, Xes
 
 ### [Mastodon](#mastodon)
 
-Join the [InstructLab Mastodon server](https://mastodon.social/@InstructLab) 
+Join the [InstructLab Mastodon server](https://mastodon.social/@InstructLab)
 to find out what's going on in the InstructLab world.
 
 ### [Bluesky](#bluesky)
 
-Follow us on [Bluesky](https://bsky.app/profile/instructlab.bsky.social). 
-This channel is currently inactive, but stay tuned for our next updates. 
+Follow us on [Bluesky](https://bsky.app/profile/instructlab.bsky.social).
+This channel is currently inactive, but stay tuned for our next updates.
 
 ### [Reddit](#reddit)
 
-Check out the [InstructLab subreddit](https://reddit.com/r/instructlab)- feel free to share 
+Check out the [InstructLab subreddit](https://reddit.com/r/instructlab)- feel free to share
 your experience with using and contributing to InstructLab. Every article is welcomed!
 
 ### [YouTube](#youtube)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -153,6 +153,8 @@ and conducted by the appropriate body:
 - Non-trivial changes to the governance (this document) (supermajority of the Oversight Committee)
 - Licensing and intellectual property changes such as new logos or wordmarks (majority of the Oversight Committee)
 - Adding, archiving, or removing projects (majority of the Oversight Committee)
+- Resolving contentious [dev-docs](https://github.com/instructlab/dev-docs/blob/main/README.md#governance) proposals
+
 
 Other decisions may be called out and put up for decision on the InstructLab
 [community mailing list](https://github.com/instructlab/community/blob/main/Collaboration.md#email-lists). This can be

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -155,7 +155,6 @@ and conducted by the appropriate body:
 - Adding, archiving, or removing projects (majority of the Oversight Committee)
 - Resolving contentious [dev-docs](https://github.com/instructlab/dev-docs/blob/main/README.md#governance) proposals
 
-
 Other decisions may be called out and put up for decision on the InstructLab
 [community mailing list](https://github.com/instructlab/community/blob/main/Collaboration.md#email-lists). This can be
 done by anyone at any time. By default, any decisions called to a vote will be for a _simple majority_ vote of the

--- a/HW_REQS.md
+++ b/HW_REQS.md
@@ -1,6 +1,6 @@
 ## 📋 Hardware requirements
 
-The local training is the most hardware intensive part of this process. 
+The local training is the most hardware intensive part of this process.
 Your hardware determines how fast/slow training the model locally will take.
 To run and train InstructLab locally, you must meet the following requirements:
 
@@ -20,5 +20,5 @@ To run and train InstructLab locally, you must meet the following requirements:
 
 > **NOTE:** Python 3.12 is currently not supported, because some dependencies don't work on Python 3.12, yet.
 <!-- -->
-> **NOTE:** When installing the `ilab` CLI on macOS, you may have to run the 
+> **NOTE:** When installing the `ilab` CLI on macOS, you may have to run the
 > `xcode-select --install` command, installing the required packages previously listed.


### PR DESCRIPTION
dev-docs was recently updated: https://github.com/instructlab/dev-docs/pull/187

to remove the OC as a primary approver of all dev docs.  Instead the OC should only be consulted when there is unresolvable (by the dev-docs maintainers) contention on a proposal.